### PR TITLE
Add forked Wayland repository as meson subproject

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "subprojects/wayland"]
+	path = subprojects/wayland
+	url = git@github.com:gray-armor/wayland.git

--- a/clients/meson.build
+++ b/clients/meson.build
@@ -7,7 +7,7 @@ source_files = [
 ]
 
 dependencies = [
-  dependency('wayland-client'),
+  wayland_proj.get_variable('wayland_client_dep')
 ]
 
 executable(

--- a/doc/CONTRIBUTING.ja.adoc
+++ b/doc/CONTRIBUTING.ja.adoc
@@ -6,11 +6,26 @@ Z11はLinuxで動作するので、開発環境もLinuxを用います.
 
 ソースコードのビルドには link:https://mesonbuild.com/index.html[meson] を用います.
 
+=== Clone
+
+submoduleを含むので
+....
+git clone --recursive git@github.com:gray-armor/z11.git
+....
+
+普通にcloneしてしまったら、
+....
+git submodule update --init --recursive
+....
+
 === Build
+
 ....
 meson --prefix=$(pwd)/target build
 ninja -C build install
 ....
+
+Wayland も一緒にビルドします。
 
 === Run
 

--- a/meson.build
+++ b/meson.build
@@ -1,8 +1,18 @@
 project(
   'z11',
   'c', 'cpp',
-  default_options : ['warning_level=3', 'werror=true', 'c_std=c11', 'cpp_std=c++17', 'optimization=2'],
+  license : 'Apache-2.0',
+  default_options : ['warning_level=3', 'werror=true', 'cpp_std=c++17', 'optimization=2'],
   meson_version : '>=0.57.0',
+)
+
+wayland_proj = subproject(
+  'wayland',
+  default_options : [
+    'documentation=false', # avoid compilation error
+    'werror=false', 'optimization=0', # back to default value
+    'warning_level=2', 'buildtype=buildtype=debugoptimized' # set wayland default options
+  ]
 )
 
 subdir('protocol')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,23 +1,22 @@
-scanner = dependency('wayland-scanner')
-scanner_path = scanner.get_variable(pkgconfig : 'wayland_scanner')
+scanner = wayland_proj.get_variable('wayland_scanner')
 
 z11_client_protocol_h = custom_target(
   'z11-client-protocol',
   output : 'z11-client-protocol.h',
   input : 'z11.xml',
-  command : [scanner_path, 'client-header', '@INPUT@', '@OUTPUT@'],
+  command : [scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
 )
 
 z11_server_protocol_h = custom_target(
   'z11-server-protocol',
   output : 'z11-server-protocol.h',
   input : 'z11.xml',
-  command : [scanner_path, 'server-header', '@INPUT@', '@OUTPUT@'],
+  command : [scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
 )
 
 z11_protocol_c = custom_target(
   'z11-protocol',
   output : 'z11-protocol.c',
   input : 'z11.xml',
-  command : [scanner_path, 'code', '@INPUT@', '@OUTPUT@'],
+  command : [scanner, 'public-code', '@INPUT@', '@OUTPUT@'],
 )

--- a/src/main.cc
+++ b/src/main.cc
@@ -46,6 +46,7 @@ void Main::ProcessRenderBlock()
   fprintf(stdout, "Listing render blocks\n");
   struct wl_list *render_blocks = compositor_->GetRenderBlocks();
   z11::RenderBlock *render_block;
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"  // FIXME: use custom list object suitable to c++
   wl_list_for_each(render_block, render_blocks, link_) { fprintf(stdout, "%s\n", render_block->sample_attr); }
   fflush(stdout);
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,7 @@ source_files = [
 ]
 
 dependencies = [
-  dependency('wayland-server'),
+  wayland_proj.get_variable('wayland_server_dep')
 ]
 
 executable(


### PR DESCRIPTION
[forkしたWayland](https://github.com/gray-armor/wayland) を git の submodule としてsubproject/waylandに配置。

mesonのsubprojectとしてビルドシステムに取り込んで、forkしたWaylandを使ってビルドするようにしました。

本当はForkしたWaylandをシステムにインストールして普通に使えばいいのかもだけど、システム環境をforkしたwaylandで汚したくない気がしたので。