### PR TITLE
remove wayland subproject

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,19 +8,37 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
       with:
-        submodules: true
+        path: main
+    - uses: actions/checkout@v2
+      with:
+        repository: gray-armor/wayland
+        path: wayland
     - uses: actions/setup-python@v1
       with:
         python-version: '3.x'
     - run: pip install meson ninja
-    - run: meson build
+
+    - run: meson -Ddocumentation=false -Dtests=false -Ddtd_validation=false -Dicon_directory=false --prefix=$(pwd)/target build
+      working-directory: ./wayland
+      env:
+        CC: gcc
+    - run: ninja -C build install
+      working-directory: ./wayland
+    - run: |
+        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/wayland/target/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+
+    - run: |
+        meson build
+      working-directory: ./main
       env:
         CC: gcc
     - run: ninja -C build test
+      working-directory: ./main
+
     - uses: actions/upload-artifact@v1
       if: failure()
       with:
         name: Test_Log
-        path: builddir/meson-logs/testlog.txt
+        path: main/build/meson-logs/testlog.txt

--- a/clients/meson.build
+++ b/clients/meson.build
@@ -5,7 +5,7 @@ client_source_files = [
 ]
 
 dependencies = [
-  wayland_proj.get_variable('wayland_client_dep')
+  dependency('wayland-client')
 ]
 
 executable(

--- a/doc/CONTRIBUTING.ja.adoc
+++ b/doc/CONTRIBUTING.ja.adoc
@@ -18,14 +18,22 @@ git clone --recursive git@github.com:gray-armor/z11.git
 git submodule update --init --recursive
 ....
 
+=== Custom Wayland
+
+カスタムされたWaylandを使うので、https://github.com/gray-armor/wayland をインストールする。
+
+....
+$ git clone git@github.com:gray-armor/wayland.git
+$ meson build
+$ ninja -C build install
+....
+
 === Build
 
 ....
 meson --prefix=$(pwd)/target build
 ninja -C build install
 ....
-
-Wayland も一緒にビルドします。
 
 === Run
 

--- a/meson.build
+++ b/meson.build
@@ -6,15 +6,6 @@ project(
   meson_version : '>=0.57.0',
 )
 
-wayland_proj = subproject(
-  'wayland',
-  default_options : [
-    'documentation=false', # avoid compilation error
-    'werror=false', 'optimization=0', # back to default value
-    'warning_level=2', 'buildtype=debugoptimized' # set wayland default options
-  ]
-)
-
 src_inc = include_directories('src')
 
 subdir('protocol')

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -1,22 +1,23 @@
-scanner = wayland_proj.get_variable('wayland_scanner')
+scanner = dependency('wayland-scanner')
+scanner_path = scanner.get_variable(pkgconfig : 'wayland_scanner')
 
 z11_client_protocol_h = custom_target(
   'z11-client-protocol',
   output : 'z11-client-protocol.h',
   input : 'z11.xml',
-  command : [scanner, 'client-header', '@INPUT@', '@OUTPUT@'],
+  command : [scanner_path, 'client-header', '@INPUT@', '@OUTPUT@'],
 )
 
 z11_server_protocol_h = custom_target(
   'z11-server-protocol',
   output : 'z11-server-protocol.h',
   input : 'z11.xml',
-  command : [scanner, 'server-header', '@INPUT@', '@OUTPUT@'],
+  command : [scanner_path, 'server-header', '@INPUT@', '@OUTPUT@'],
 )
 
 z11_protocol_c = custom_target(
   'z11-protocol',
   output : 'z11-protocol.c',
   input : 'z11.xml',
-  command : [scanner, 'public-code', '@INPUT@', '@OUTPUT@'],
+  command : [scanner_path, 'public-code', '@INPUT@', '@OUTPUT@'],
 )

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,7 +16,7 @@ source_files = files([
 ]
 
 dependencies = [
-  wayland_proj.get_variable('wayland_server_dep')
+  dependency('wayland-server')
 ]
 
 executable(

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,6 +1,6 @@
 dependencies = [
-  wayland_proj.get_variable('wayland_server_dep'),
-  wayland_proj.get_variable('wayland_client_dep')
+  dependency('wayland-server'),
+  dependency('wayland-client'),
 ]
 
 render_block_test = executable(


### PR DESCRIPTION
wayland を meson subprojectとして扱っていたのをやめる。

READMEに書いたが、普通に https://github.com/gray-armor/wayland をシステムにインストールして使うことにする。