### PR TITLE
render block with simple line draw capability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update &&
+        sudo apt-get install libglew-dev libsdl2-dev
     - uses: actions/checkout@v2
       with:
         path: main

--- a/clients/simple_box.c
+++ b/clients/simple_box.c
@@ -61,8 +61,73 @@ const struct wl_registry_listener registry_listener = {
     global_registry_remover,
 };
 
-int main()
+typedef struct {
+  float x, y, z;
+} Point;
+
+typedef struct {
+  Point start, end;
+} Line;
+
+static void paint(Line *out, int x, int y, int z)
 {
+  Point A = {x - 5, y - 5, z - 5};
+  Point B = {x + 5, y - 5, z - 5};
+  Point C = {x + 5, y + 5, z - 5};
+  Point D = {x - 5, y + 5, z - 5};
+  Point E = {x - 5, y - 5, z + 5};
+  Point F = {x + 5, y - 5, z + 5};
+  Point G = {x + 5, y + 5, z + 5};
+  Point H = {x - 5, y + 5, z + 5};
+
+  out->start = A;
+  out->end = B;
+  out++;
+  out->start = B;
+  out->end = C;
+  out++;
+  out->start = C;
+  out->end = D;
+  out++;
+  out->start = D;
+  out->end = A;
+  out++;
+
+  out->start = E;
+  out->end = F;
+  out++;
+  out->start = F;
+  out->end = G;
+  out++;
+  out->start = G;
+  out->end = H;
+  out++;
+  out->start = H;
+  out->end = E;
+  out++;
+
+  out->start = A;
+  out->end = E;
+  out++;
+  out->start = B;
+  out->end = F;
+  out++;
+  out->start = C;
+  out->end = G;
+  out++;
+  out->start = D;
+  out->end = H;
+}
+
+int main(int argc, char const *argv[])
+{
+  int x = 0;
+  int y = 0;
+  int z = 20;
+  if (argc > 1) x = atoi(argv[1]);
+  if (argc > 2) y = atoi(argv[2]);
+  if (argc > 3) z = atoi(argv[3]);
+
   struct wl_display *display = wl_display_connect(NULL);
   if (display == NULL) {
     fprintf(stderr, "Can't connect to display\n");
@@ -78,15 +143,16 @@ int main()
 
   assert(compositor && shm);
 
-  int size = 1024;
+  int size = sizeof(Line) * 12;
   int fd = create_shared_fd(size);
-  void *shm_data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  Line *shm_data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
   if (shm_data == MAP_FAILED) {
 #pragma GCC diagnostic ignored "-Wformat"
     fprintf(stderr, "mmap failed: %m\n");
     close(fd);
     exit(1);
   }
+  paint(shm_data, x, y, z);
 
   struct wl_shm_pool *pool = wl_shm_create_pool(shm, fd, size);
   struct wl_raw_buffer *buffer = wl_shm_pool_create_raw_buffer(pool, 0, size);

--- a/compositor/eye.cc
+++ b/compositor/eye.cc
@@ -1,0 +1,34 @@
+#include "eye.h"
+
+#include <GL/glew.h>
+
+bool Eye::Init(uint32_t renderWidth, uint32_t renderHeight)
+{
+  width_ = renderWidth;
+  height_ = renderHeight;
+
+  if (CreateFramebuffer() == false) return false;
+  return true;
+}
+
+bool Eye::CreateFramebuffer()
+{
+  glGenFramebuffers(1, &framebuffer_id_);
+  glBindFramebuffer(GL_FRAMEBUFFER, framebuffer_id_);
+
+  glGenRenderbuffers(1, &depthbuffer_id_);
+  glBindRenderbuffer(GL_RENDERBUFFER, depthbuffer_id_);
+  glRenderbufferStorageMultisample(GL_RENDERBUFFER, 4, GL_DEPTH_COMPONENT, width_, height_);
+  glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, depthbuffer_id_);
+
+  glGenTextures(1, &texture_id_);
+  glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, texture_id_);
+  glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, 4, GL_RGBA8, width_, height_, true);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, texture_id_, 0);
+  GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+  if (status != GL_FRAMEBUFFER_COMPLETE) return false;
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+  return true;
+}

--- a/compositor/eye.h
+++ b/compositor/eye.h
@@ -1,0 +1,38 @@
+#ifndef Z11_EYE_H
+#define Z11_EYE_H
+
+#include <GL/glew.h>
+#include <z11/matrices.h>
+
+class Eye
+{
+ public:
+  bool Init(uint32_t renderWidth, uint32_t renderHeight);
+  void set_projection(Matrix4 projection);
+  Matrix4 projection();
+  GLuint framebuffer_id();
+  uint32_t width();
+  uint32_t height();
+
+ private:
+  uint32_t width_;
+  uint32_t height_;
+  Matrix4 projection_;
+  GLuint framebuffer_id_;
+  GLuint texture_id_;
+  GLuint depthbuffer_id_;
+
+ private:
+  bool CreateFramebuffer();
+};
+
+inline void Eye::set_projection(Matrix4 projection) { projection_ = projection; }
+
+inline Matrix4 Eye::projection() { return projection_; }
+
+inline GLuint Eye::framebuffer_id() { return framebuffer_id_; }
+
+inline uint32_t Eye::width() { return width_; }
+inline uint32_t Eye::height() { return height_; }
+
+#endif  // Z11_EYE_H

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -1,5 +1,9 @@
+#include <SDL2/SDL.h>
 #include <libz11.h>
-#include <stdio.h>
+
+#include "eye.h"
+#include "renderer.h"
+#include "sdl.h"
 
 class Main
 {
@@ -8,14 +12,21 @@ class Main
   bool Init();
   void RunMainLoop();
   void Shutdown();
-  void ProcessRenderBlock();
 
  private:
   z11::Compositor *compositor_;
+  Eye *left_eye_;
+  Eye *right_eye_;
+  Renderer *renderer_;
+
+  SDLHead *head_;
   bool run_;
+
+ private:
+  void SetEyeProjection();
 };
 
-Main::Main() : compositor_(nullptr), run_(false)
+Main::Main() : run_(false)
 {
   // TODO: handle args and envs
 }
@@ -24,6 +35,28 @@ bool Main::Init()
 {
   compositor_ = z11::Compositor::Create();
   if (compositor_ == nullptr) return false;
+
+  head_ = new SDLHead();
+  if (head_->Init() == false) return false;
+
+  GLenum glewError = glewInit();
+  if (glewError != GLEW_OK) {
+    fprintf(stdout, "%s - Error initializing GLEW! %s\n", __FUNCTION__, glewGetErrorString(glewError));
+    return false;
+  }
+  glGetError();
+
+  renderer_ = new Renderer();
+  if (renderer_->Init() == false) return false;
+
+  left_eye_ = new Eye();
+  right_eye_ = new Eye();
+  if (left_eye_->Init(320, 320) == false) return false;
+  if (right_eye_->Init(320, 320) == false) return false;
+  SetEyeProjection();
+
+  if (head_->InitGL(left_eye_, right_eye_) == false) return false;
+
   return true;
 }
 
@@ -32,22 +65,18 @@ void Main::RunMainLoop()
   run_ = true;
   while (run_) {
     compositor_->ProcessEvents();
-    ProcessRenderBlock();
+
+    run_ = head_->ProcessEvents();
+
+    renderer_->Render(left_eye_, compositor_->render_block_list());
+    renderer_->Render(right_eye_, compositor_->render_block_list());
+
+    head_->Draw(left_eye_, right_eye_);
+    head_->Swap();
   }
 }
 
-void Main::Shutdown() {}
-
-void Main::ProcessRenderBlock()
-{
-  fprintf(stdout, "\033[2J\033[0;0H");  // clear console
-  fprintf(stdout, "Listing render blocks\n");
-  struct wl_list *render_blocks = compositor_->GetRenderBlocks();
-  z11::RenderBlock *render_block;
-#pragma GCC diagnostic ignored "-Winvalid-offsetof"  // FIXME: use custom list object suitable to c++
-  wl_list_for_each(render_block, render_blocks, link_) { fprintf(stdout, "%s\n", render_block->sample_attr); }
-  fflush(stdout);
-}
+void Main::Shutdown() { head_->Shutdown(); }
 
 int main()
 {
@@ -60,4 +89,43 @@ int main()
 
   main->Shutdown();
   return 0;
+}
+
+void Main::SetEyeProjection()
+{
+  float far = 1000;
+  float near = 0.001;
+  float e = 2 * (far * near) / (near - far);
+  float f = (far + near) / (far - near);
+
+  Matrix4 projection_left = Matrix4(  //
+      1, 0, 0, 0,                     //
+      0, 1, 0, 0,                     //
+      0, 0, f, 1,                     //
+      0, 0, e, 0                      //
+  );
+
+  Matrix4 projection_right = Matrix4(  //
+      1, 0, 0, 0,                      //
+      0, 1, 0, 0,                      //
+      0, 0, f, 1,                      //
+      0, 0, e, 0                       //
+  );
+
+  Matrix4 eye_pos_left = Matrix4(  //
+      1, 0, 0, 0,                  //
+      0, 1, 0, 0,                  //
+      0, 0, 1, 0,                  //
+      1, 0, 0, 1                   //
+  );
+
+  Matrix4 eye_pos_right = Matrix4(  //
+      1, 0, 0, 0,                   //
+      0, 1, 0, 0,                   //
+      0, 0, 1, 0,                   //
+      -1, 0, 0, 1                   //
+  );
+
+  left_eye_->set_projection(projection_left * eye_pos_left);
+  right_eye_->set_projection(projection_right * eye_pos_right);
 }

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -1,6 +1,24 @@
+dep_compositor = [
+  libz11_public_dep,
+  dependency('sdl2'),
+  dependency('glew'),
+]
+
+src_compositor = [
+  'main.cc',
+  'eye.cc',
+  'eye.h',
+  'renderer.cc',
+  'renderer.h',
+  'sdl.cc',
+  'sdl.h',
+  'shader.cc',
+  'shader.h',
+]
+
 executable(
   meson.project_name(),
-  'main.cc',
+  src_compositor,
   install : true,
-  dependencies : libz11_public_dep,
+  dependencies : dep_compositor,
 )

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -1,0 +1,62 @@
+#include "renderer.h"
+
+#include <libz11.h>
+
+bool Renderer::Init()
+{
+  if (default_shader_.Init(  //
+          "Scene",
+
+          // Vertex Shader
+          "#version 410\n"
+          "uniform mat4 matrix;\n"
+          "layout(location = 0) in vec4 position;\n"
+          "layout(location = 1) in vec2 v2UVcoordsIn;\n"
+          "layout(location = 2) in vec3 v3NormalIn;\n"
+          "out vec2 v2UVcoords;\n"
+          "void main()\n"
+          "{\n"
+          "  v2UVcoords = v2UVcoordsIn;\n"
+          "  gl_Position = matrix * position;\n"
+          "}\n",
+
+          // Fragment Shader
+          "#version 410 core\n"
+          "in vec2 v2UVcoords;\n"
+          "out vec4 outputColor;\n"
+          "void main()\n"
+          "{\n"
+          "  outputColor = vec4(1.0, 0.0, 0.0, 1.0);"
+          "}\n") == false)
+    return false;
+  default_shader_matrix_location_ = glGetUniformLocation(default_shader_.id(), "matrix");
+
+  return true;
+}
+
+void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list)
+{
+  z11::List<z11::RenderBlock> *block = render_block_list->next();
+
+  glEnable(GL_MULTISAMPLE);
+  glBindFramebuffer(GL_FRAMEBUFFER, eye->framebuffer_id());
+  glViewport(0, 0, eye->width(), eye->height());
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+
+  if (render_block_list->Empty()) goto clean;
+
+  glEnable(GL_DEPTH_TEST);
+  glUseProgram(default_shader_.id());
+  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->projection().get());
+  do {
+    glBindVertexArray(block->data()->vertex_array_object());
+    glDrawArrays(GL_LINES, 0, block->data()->GetDataSize() / (sizeof(float) * 3));
+    glBindVertexArray(0);
+    block = block->next();
+  } while (!block->Head());
+  glUseProgram(0);
+
+clean:
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glDisable(GL_MULTISAMPLE);
+}

--- a/compositor/renderer.h
+++ b/compositor/renderer.h
@@ -1,0 +1,21 @@
+#ifndef Z11_RENDERER_H
+#define Z11_RENDERER_H
+
+#include <GL/glew.h>
+#include <libz11.h>
+
+#include "eye.h"
+#include "shader.h"
+
+class Renderer
+{
+ public:
+  bool Init();
+  void Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list);
+
+ private:
+  Shader default_shader_;
+  GLint default_shader_matrix_location_;
+};
+
+#endif  // Z11_RENDERER_H

--- a/compositor/sdl.cc
+++ b/compositor/sdl.cc
@@ -1,0 +1,229 @@
+#include "sdl.h"
+
+#include <GL/glew.h>
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_opengl.h>
+
+#include <vector>
+
+#include "eye.h"
+
+bool SDLHead::Init()
+{
+  if (SDL_Init(SDL_INIT_VIDEO) < 0) return false;
+
+  int windowPosX = 700;
+  int windowPosY = 100;
+  int windowWidth = 640;
+  int windowHeight = 320;
+
+  Uint32 windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN;
+
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+  SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+
+  window_ =
+      SDL_CreateWindow("z11 sdl window", windowPosX, windowPosY, windowWidth, windowHeight, windowFlags);
+  if (window_ == nullptr) return false;
+
+  gl_context_ = SDL_GL_CreateContext(window_);
+  if (gl_context_ == nullptr) return false;
+
+  return true;
+}
+
+bool SDLHead::InitGL(Eye *left_eye, Eye *right_eye)
+{
+  // create framebuffer for left eye copy
+  glGenFramebuffers(1, &left_copy_framebuffer_id_);
+  glBindFramebuffer(GL_FRAMEBUFFER, left_copy_framebuffer_id_);
+
+  glGenTextures(1, &left_copy_texture_id_);
+  glBindTexture(GL_TEXTURE_2D, left_copy_texture_id_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, left_eye->width(), left_eye->height(), 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, nullptr);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, left_copy_texture_id_, 0);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+  // create framebuffer for right eye copy
+  glGenFramebuffers(1, &right_copy_framebuffer_id_);
+  glBindFramebuffer(GL_FRAMEBUFFER, right_copy_framebuffer_id_);
+
+  glGenTextures(1, &right_copy_texture_id_);
+  glBindTexture(GL_TEXTURE_2D, right_copy_texture_id_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, right_eye->width(), right_eye->height(), 0, GL_RGBA,
+               GL_UNSIGNED_BYTE, nullptr);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, right_copy_texture_id_, 0);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+  // prepare shader
+  if (default_shader_.Init(  //
+          "CompanionWindow",
+
+          // vertex shader
+          "#version 410 core\n"
+          "layout(location = 0) in vec4 position;\n"
+          "layout(location = 1) in vec2 v2UVIn;\n"
+          "noperspective out vec2 v2UV;\n"
+          "void main()\n"
+          "{\n"
+          "	v2UV = v2UVIn;\n"
+          "	gl_Position = position;\n"
+          "}\n",
+
+          // fragment shader
+          "#version 410 core\n"
+          "uniform sampler2D mytexture;\n"
+          "noperspective in vec2 v2UV;\n"
+          "out vec4 outputColor;\n"
+          "void main()\n"
+          "{\n"
+          // "  outputColor = vec4(1.0, 0.0, 0.0, 1.0);"
+          "  outputColor = texture(mytexture, v2UV);\n"
+          "}\n") == false)
+    return false;
+
+  // create scene
+  std::vector<VertexDataWindow> verts;
+
+  // left eye verts
+  verts.push_back(VertexDataWindow(Vector2(-1, -1), Vector2(0, 0)));
+  verts.push_back(VertexDataWindow(Vector2(0, -1), Vector2(1, 0)));
+  verts.push_back(VertexDataWindow(Vector2(-1, 1), Vector2(0, 1)));
+  verts.push_back(VertexDataWindow(Vector2(0, 1), Vector2(1, 1)));
+
+  // right eye verts
+  verts.push_back(VertexDataWindow(Vector2(0, -1), Vector2(0, 0)));
+  verts.push_back(VertexDataWindow(Vector2(1, -1), Vector2(1, 0)));
+  verts.push_back(VertexDataWindow(Vector2(0, 1), Vector2(0, 1)));
+  verts.push_back(VertexDataWindow(Vector2(1, 1), Vector2(1, 1)));
+
+  GLushort indices[] = {0, 1, 3, 0, 3, 2, 4, 5, 7, 4, 7, 6};
+  index_size_ = sizeof(indices) / sizeof(indices[0]);
+
+  glGenVertexArrays(1, &vertex_array_object_);
+  glBindVertexArray(vertex_array_object_);
+
+  glGenBuffers(1, &vertex_buffer_);
+  glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);
+  glBufferData(GL_ARRAY_BUFFER, verts.size() * sizeof(VertexDataWindow), &verts[0], GL_STATIC_DRAW);
+
+  glGenBuffers(1, &index_buffer_);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, index_buffer_);
+  glBufferData(GL_ELEMENT_ARRAY_BUFFER, index_size_ * sizeof(GLushort), &indices[0], GL_STATIC_DRAW);
+
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, sizeof(VertexDataWindow),
+                        (void *)offsetof(VertexDataWindow, position));
+
+  glEnableVertexAttribArray(1);
+  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(VertexDataWindow),
+                        (void *)offsetof(VertexDataWindow, texCoord));
+
+  glBindVertexArray(0);
+
+  glDisableVertexAttribArray(0);
+  glDisableVertexAttribArray(1);
+
+  glBindBuffer(GL_ARRAY_BUFFER, 0);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+
+  return true;
+}
+
+void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
+{
+  // copy left eye
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, left_eye->framebuffer_id());
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, left_copy_framebuffer_id_);
+
+  glBlitFramebuffer(0, 0, left_eye->width(), left_eye->height(), 0, 0, left_eye->width(), left_eye->height(),
+                    GL_COLOR_BUFFER_BIT, GL_LINEAR);
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+
+  // copy right eye
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, right_eye->framebuffer_id());
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, right_copy_framebuffer_id_);
+
+  glBlitFramebuffer(0, 0, right_eye->width(), right_eye->height(), 0, 0, right_eye->width(),
+                    right_eye->height(), GL_COLOR_BUFFER_BIT, GL_LINEAR);
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+
+  // draw from copied buffer to default frame buffer
+  glDisable(GL_DEPTH_TEST);
+  glViewport(0, 0, left_eye->width() + right_eye->width(), left_eye->height());
+
+  glBindVertexArray(vertex_array_object_);
+  glUseProgram(default_shader_.id());
+
+  glBindTexture(GL_TEXTURE_2D, left_copy_texture_id_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glDrawElements(GL_TRIANGLES, index_size_ / 2, GL_UNSIGNED_SHORT, 0);
+
+  glBindTexture(GL_TEXTURE_2D, right_copy_texture_id_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glDrawElements(GL_TRIANGLES, index_size_ / 2, GL_UNSIGNED_SHORT, (const void *)(uintptr_t)(index_size_));
+
+  glBindVertexArray(0);
+  glUseProgram(0);
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+}
+
+void SDLHead::Swap()
+{
+  // Swap from default framebuffer
+  SDL_GL_SwapWindow(window_);
+  glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
+}
+
+bool SDLHead::ProcessEvents()
+{
+  SDL_Event sdlEvent;
+  while (SDL_PollEvent(&sdlEvent) != 0) {
+    switch (sdlEvent.type) {
+      case SDL_QUIT:
+        return false;
+        break;
+
+      case SDL_WINDOWEVENT:
+        switch (sdlEvent.window.event) {
+          case SDL_WINDOWEVENT_CLOSE:
+            return false;
+            break;
+
+          default:
+            break;
+        }
+        break;
+
+      default:
+        break;
+    }
+  }
+  return true;
+}
+
+void SDLHead::Shutdown()
+{
+  if (window_) {
+    SDL_DestroyWindow(window_);
+    window_ = nullptr;
+  }
+
+  SDL_Quit();
+}

--- a/compositor/sdl.h
+++ b/compositor/sdl.h
@@ -1,0 +1,40 @@
+#ifndef Z11_SDL_H
+#define Z11_SDL_H
+
+#include <SDL2/SDL.h>
+#include <z11/vectors.h>
+
+#include "eye.h"
+#include "shader.h"
+
+struct VertexDataWindow {
+  Vector2 position;
+  Vector2 texCoord;
+  VertexDataWindow(const Vector2 &pos, const Vector2 tex) : position(pos), texCoord(tex) {}
+};
+
+class SDLHead
+{
+ public:
+  bool Init();
+  bool InitGL(Eye *left_eye, Eye *right_eye);
+  bool ProcessEvents();
+  void Draw(Eye *left_eye, Eye *right_eye);
+  void Swap();
+  void Shutdown();
+
+ private:
+  SDL_Window *window_;
+  SDL_GLContext gl_context_;
+  GLuint left_copy_framebuffer_id_;
+  GLuint left_copy_texture_id_;
+  GLuint right_copy_framebuffer_id_;
+  GLuint right_copy_texture_id_;
+  uint32_t index_size_;
+  GLuint vertex_array_object_;
+  GLuint vertex_buffer_;
+  GLuint index_buffer_;
+  Shader default_shader_;
+};
+
+#endif  // Z11_SDL_H

--- a/compositor/shader.cc
+++ b/compositor/shader.cc
@@ -1,0 +1,58 @@
+#include "shader.h"
+
+#include <GL/glew.h>
+#include <stdio.h>
+
+bool Shader::Init(const char *shader_name, const char *vertex_shader, const char *fragment_shader)
+{
+  id_ = glCreateProgram();
+
+  // compile vertex shader
+  GLuint scene_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(scene_vertex_shader, 1, &vertex_shader, NULL);
+  glCompileShader(scene_vertex_shader);
+
+  GLint vertex_shader_compiled = GL_FALSE;
+  glGetShaderiv(scene_vertex_shader, GL_COMPILE_STATUS, &vertex_shader_compiled);
+  if (vertex_shader_compiled != GL_TRUE) {
+    fprintf(stderr, "%s - Unable to compile vertex shader %d!\n", shader_name, scene_vertex_shader);
+    glDeleteProgram(id_);
+    glDeleteShader(scene_vertex_shader);
+    return false;
+  }
+  glAttachShader(id_, scene_vertex_shader);
+  glDeleteShader(scene_vertex_shader);
+
+  // compile fragmen shader
+  GLuint scene_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(scene_fragment_shader, 1, &fragment_shader, NULL);
+  glCompileShader(scene_fragment_shader);
+
+  GLint fragment_shader_compiled = GL_FALSE;
+  glGetShaderiv(scene_fragment_shader, GL_COMPILE_STATUS, &fragment_shader_compiled);
+  if (fragment_shader_compiled != GL_TRUE) {
+    fprintf(stderr, "%s - Unable to compile fragment shader %d!\n", shader_name, scene_fragment_shader);
+    glDeleteProgram(id_);
+    glDeleteShader(scene_fragment_shader);
+    return false;
+  }
+
+  glAttachShader(id_, scene_fragment_shader);
+  glDeleteShader(scene_fragment_shader);
+
+  // check
+  glLinkProgram(id_);
+
+  GLint program_success = GL_TRUE;
+  glGetProgramiv(id_, GL_LINK_STATUS, &program_success);
+  if (program_success != GL_TRUE) {
+    fprintf(stderr, "%s - Error linking program %d!\n", shader_name, id_);
+    glDeleteProgram(id_);
+    return false;
+  }
+
+  glUseProgram(id_);
+  glUseProgram(0);
+
+  return true;
+}

--- a/compositor/shader.h
+++ b/compositor/shader.h
@@ -1,0 +1,18 @@
+#ifndef Z11_SHADER_H
+#define Z11_SHADER_H
+
+#include <GL/glew.h>
+
+class Shader
+{
+ public:
+  bool Init(const char *shader_name, const char *vertex_shader, const char *fragment_shader);
+  GLuint id();
+
+ private:
+  GLuint id_;
+};
+
+inline GLuint Shader::id() { return id_; }
+
+#endif  // Z11_SHADER_H

--- a/doc/CONTRIBUTING.ja.adoc
+++ b/doc/CONTRIBUTING.ja.adoc
@@ -40,8 +40,16 @@ $ XDG_RUNTIME_DIR=~/.xdg z11
 ....
 
 run z client
+
+立方体を画面に書きます。
+
 ....
-$ XDG_RUNTIME_DIR=~/.xdg z11-simple-box
+$ XDG_RUNTIME_DIR=~/.xdg z11-simple-box -13 -1 20 # x y z
+....
+
+別のシェルで
+....
+$ XDG_RUNTIME_DIR=~/.xdg z11-simple-box 3 -11 15
 ....
 
 === Tip

--- a/include/meson.build
+++ b/include/meson.build
@@ -1,1 +1,4 @@
 install_headers('libz11.h')
+install_headers('./z11/list.h', subdir : 'z11')
+install_headers('./z11/matrices.h', subdir : 'z11')
+install_headers('./z11/vectors.h', subdir : 'z11')

--- a/include/z11/list.h
+++ b/include/z11/list.h
@@ -1,0 +1,92 @@
+#ifndef LIBZ11_LIST_H
+#define LIBZ11_LIST_H
+
+namespace z11 {
+template <class T>
+class List
+{
+ public:
+  List();
+  List(T* data);
+
+  void Insert(List<T>* elem);
+  void Remove();
+  bool Empty();
+  bool Head();
+  List<T>* prev();
+  List<T>* next();
+  T* data();
+
+ private:
+  List<T>* prev_;
+  List<T>* next_;
+  T* data_;
+};
+
+template <class T>
+inline List<T>* List<T>::prev()
+{
+  return prev_;
+}
+
+template <class T>
+inline List<T>* List<T>::next()
+{
+  return next_;
+}
+
+template <class T>
+inline T* List<T>::data()
+{
+  return data_;
+}
+
+template <class T>
+List<T>::List()
+{
+  this->data_ = nullptr;
+  this->next_ = this;
+  this->prev_ = this;
+}
+
+template <class T>
+List<T>::List(T* data)
+{
+  this->data_ = data;
+  this->next_ = nullptr;
+  this->prev_ = nullptr;
+}
+
+template <class T>
+void List<T>::Insert(List<T>* elem)
+{
+  elem->prev_ = this;
+  elem->next_ = this->next_;
+  this->next_ = elem;
+  elem->next_->prev_ = elem;
+}
+
+template <class T>
+void List<T>::Remove()
+{
+  this->prev_->next_ = this->next_;
+  this->next_->prev_ = this->prev_;
+  this->prev_ = nullptr;
+  this->next_ = nullptr;
+}
+
+template <class T>
+bool List<T>::Empty()
+{
+  return this->next_ == this;
+}
+
+template <class T>
+bool List<T>::Head()
+{
+  return this->data_ == nullptr;
+}
+
+}  // namespace z11
+
+#endif  // LIBZ11_LIST_H

--- a/include/z11/matrices.h
+++ b/include/z11/matrices.h
@@ -1,0 +1,827 @@
+///////////////////////////////////////////////////////////////////////////////
+// matrices.h
+// =========
+// NxN Matrix Math classes
+//
+// The elements of the matrix are stored as column major order.
+// | 0 2 |    | 0 3 6 |    |  0  4  8 12 |
+// | 1 3 |    | 1 4 7 |    |  1  5  9 13 |
+//            | 2 5 8 |    |  2  6 10 14 |
+//                         |  3  7 11 15 |
+//
+//  AUTHOR: Song Ho Ahn (song.ahn@gmail.com)
+// CREATED: 2005-06-24
+// UPDATED: 2013-09-30
+//
+// Copyright (C) 2005 Song Ho Ahn
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef LIBZ11_MATRICES_H
+#define LIBZ11_MATRICES_H
+
+#include <iomanip>
+#include <iostream>
+
+#include "vectors.h"
+
+///////////////////////////////////////////////////////////////////////////
+// 2x2 matrix
+///////////////////////////////////////////////////////////////////////////
+class Matrix2
+{
+ public:
+  // constructors
+  Matrix2();  // init with identity
+  Matrix2(const float src[4]);
+  Matrix2(float m0, float m1, float m2, float m3);
+
+  void set(const float src[4]);
+  void set(float m0, float m1, float m2, float m3);
+  void setRow(int index, const float row[2]);
+  void setRow(int index, const Vector2& v);
+  void setColumn(int index, const float col[2]);
+  void setColumn(int index, const Vector2& v);
+
+  const float* get() const;
+  float getDeterminant();
+
+  Matrix2& identity();
+  Matrix2& transpose();  // transpose itself and return reference
+  Matrix2& invert();
+
+  // operators
+  Matrix2 operator+(const Matrix2& rhs) const;  // add rhs
+  Matrix2 operator-(const Matrix2& rhs) const;  // subtract rhs
+  Matrix2& operator+=(const Matrix2& rhs);      // add rhs and update this object
+  Matrix2& operator-=(const Matrix2& rhs);      // subtract rhs and update this object
+  Vector2 operator*(const Vector2& rhs) const;  // multiplication: v' = M * v
+  Matrix2 operator*(const Matrix2& rhs) const;  // multiplication: M3 = M1 * M2
+  Matrix2& operator*=(const Matrix2& rhs);      // multiplication: M1' = M1 * M2
+  bool operator==(const Matrix2& rhs) const;    // exact compare, no epsilon
+  bool operator!=(const Matrix2& rhs) const;    // exact compare, no epsilon
+  float operator[](int index) const;            // subscript operator v[0], v[1]
+  float& operator[](int index);                 // subscript operator v[0], v[1]
+
+  friend Matrix2 operator-(const Matrix2& m);                      // unary operator (-)
+  friend Matrix2 operator*(float scalar, const Matrix2& m);        // pre-multiplication
+  friend Vector2 operator*(const Vector2& vec, const Matrix2& m);  // pre-multiplication
+  friend std::ostream& operator<<(std::ostream& os, const Matrix2& m);
+
+ protected:
+ private:
+  float m[4];
+};
+
+///////////////////////////////////////////////////////////////////////////
+// 3x3 matrix
+///////////////////////////////////////////////////////////////////////////
+class Matrix3
+{
+ public:
+  // constructors
+  Matrix3();  // init with identity
+  Matrix3(const float src[9]);
+  Matrix3(float m0, float m1, float m2,   // 1st column
+          float m3, float m4, float m5,   // 2nd column
+          float m6, float m7, float m8);  // 3rd column
+
+  void set(const float src[9]);
+  void set(float m0, float m1, float m2,   // 1st column
+           float m3, float m4, float m5,   // 2nd column
+           float m6, float m7, float m8);  // 3rd column
+  void setRow(int index, const float row[3]);
+  void setRow(int index, const Vector3& v);
+  void setColumn(int index, const float col[3]);
+  void setColumn(int index, const Vector3& v);
+
+  const float* get() const;
+  float getDeterminant();
+
+  Matrix3& identity();
+  Matrix3& transpose();  // transpose itself and return reference
+  Matrix3& invert();
+
+  // operators
+  Matrix3 operator+(const Matrix3& rhs) const;  // add rhs
+  Matrix3 operator-(const Matrix3& rhs) const;  // subtract rhs
+  Matrix3& operator+=(const Matrix3& rhs);      // add rhs and update this object
+  Matrix3& operator-=(const Matrix3& rhs);      // subtract rhs and update this object
+  Vector3 operator*(const Vector3& rhs) const;  // multiplication: v' = M * v
+  Matrix3 operator*(const Matrix3& rhs) const;  // multiplication: M3 = M1 * M2
+  Matrix3& operator*=(const Matrix3& rhs);      // multiplication: M1' = M1 * M2
+  bool operator==(const Matrix3& rhs) const;    // exact compare, no epsilon
+  bool operator!=(const Matrix3& rhs) const;    // exact compare, no epsilon
+  float operator[](int index) const;            // subscript operator v[0], v[1]
+  float& operator[](int index);                 // subscript operator v[0], v[1]
+
+  friend Matrix3 operator-(const Matrix3& m);                      // unary operator (-)
+  friend Matrix3 operator*(float scalar, const Matrix3& m);        // pre-multiplication
+  friend Vector3 operator*(const Vector3& vec, const Matrix3& m);  // pre-multiplication
+  friend std::ostream& operator<<(std::ostream& os, const Matrix3& m);
+
+ protected:
+ private:
+  float m[9];
+};
+
+///////////////////////////////////////////////////////////////////////////
+// 4x4 matrix
+///////////////////////////////////////////////////////////////////////////
+class Matrix4
+{
+ public:
+  // constructors
+  Matrix4();  // init with identity
+  Matrix4(const float src[16]);
+  Matrix4(float m00, float m01, float m02, float m03,   // 1st column
+          float m04, float m05, float m06, float m07,   // 2nd column
+          float m08, float m09, float m10, float m11,   // 3rd column
+          float m12, float m13, float m14, float m15);  // 4th column
+
+  void set(const float src[16]);
+  void set(float m00, float m01, float m02, float m03,   // 1st column
+           float m04, float m05, float m06, float m07,   // 2nd column
+           float m08, float m09, float m10, float m11,   // 3rd column
+           float m12, float m13, float m14, float m15);  // 4th column
+  void setRow(int index, const float row[4]);
+  void setRow(int index, const Vector4& v);
+  void setRow(int index, const Vector3& v);
+  void setColumn(int index, const float col[4]);
+  void setColumn(int index, const Vector4& v);
+  void setColumn(int index, const Vector3& v);
+
+  const float* get() const;
+  const float* getTranspose();  // return transposed matrix
+  float getDeterminant();
+
+  Matrix4& identity();
+  Matrix4& transpose();         // transpose itself and return reference
+  Matrix4& invert();            // check best inverse method before inverse
+  Matrix4& invertEuclidean();   // inverse of Euclidean transform matrix
+  Matrix4& invertAffine();      // inverse of affine transform matrix
+  Matrix4& invertProjective();  // inverse of projective matrix using partitioning
+  Matrix4& invertGeneral();     // inverse of generic matrix
+
+  // transform matrix
+  Matrix4& translate(float x, float y, float z);      // translation by (x,y,z)
+  Matrix4& translate(const Vector3& v);               //
+  Matrix4& rotate(float angle, const Vector3& axis);  // rotate angle(degree) along the given axix
+  Matrix4& rotate(float angle, float x, float y, float z);
+  Matrix4& rotateX(float angle);                 // rotate on X-axis with degree
+  Matrix4& rotateY(float angle);                 // rotate on Y-axis with degree
+  Matrix4& rotateZ(float angle);                 // rotate on Z-axis with degree
+  Matrix4& scale(float scale);                   // uniform scale
+  Matrix4& scale(float sx, float sy, float sz);  // scale by (sx, sy, sz) on each axis
+
+  // operators
+  Matrix4 operator+(const Matrix4& rhs) const;  // add rhs
+  Matrix4 operator-(const Matrix4& rhs) const;  // subtract rhs
+  Matrix4& operator+=(const Matrix4& rhs);      // add rhs and update this object
+  Matrix4& operator-=(const Matrix4& rhs);      // subtract rhs and update this object
+  Vector4 operator*(const Vector4& rhs) const;  // multiplication: v' = M * v
+  Vector3 operator*(const Vector3& rhs) const;  // multiplication: v' = M * v
+  Matrix4 operator*(const Matrix4& rhs) const;  // multiplication: M3 = M1 * M2
+  Matrix4& operator*=(const Matrix4& rhs);      // multiplication: M1' = M1 * M2
+  bool operator==(const Matrix4& rhs) const;    // exact compare, no epsilon
+  bool operator!=(const Matrix4& rhs) const;    // exact compare, no epsilon
+  float operator[](int index) const;            // subscript operator v[0], v[1]
+  float& operator[](int index);                 // subscript operator v[0], v[1]
+
+  friend Matrix4 operator-(const Matrix4& m);                      // unary operator (-)
+  friend Matrix4 operator*(float scalar, const Matrix4& m);        // pre-multiplication
+  friend Vector3 operator*(const Vector3& vec, const Matrix4& m);  // pre-multiplication
+  friend Vector4 operator*(const Vector4& vec, const Matrix4& m);  // pre-multiplication
+  friend std::ostream& operator<<(std::ostream& os, const Matrix4& m);
+
+ protected:
+ private:
+  float getCofactor(float m0, float m1, float m2, float m3, float m4, float m5, float m6, float m7, float m8);
+
+  float m[16];
+  float tm[16];  // transpose m
+};
+
+///////////////////////////////////////////////////////////////////////////
+// inline functions for Matrix2
+///////////////////////////////////////////////////////////////////////////
+inline Matrix2::Matrix2()
+{
+  // initially identity matrix
+  identity();
+}
+
+inline Matrix2::Matrix2(const float src[4]) { set(src); }
+
+inline Matrix2::Matrix2(float m0, float m1, float m2, float m3) { set(m0, m1, m2, m3); }
+
+inline void Matrix2::set(const float src[4])
+{
+  m[0] = src[0];
+  m[1] = src[1];
+  m[2] = src[2];
+  m[3] = src[3];
+}
+
+inline void Matrix2::set(float m0, float m1, float m2, float m3)
+{
+  m[0] = m0;
+  m[1] = m1;
+  m[2] = m2;
+  m[3] = m3;
+}
+
+inline void Matrix2::setRow(int index, const float row[2])
+{
+  m[index] = row[0];
+  m[index + 2] = row[1];
+}
+
+inline void Matrix2::setRow(int index, const Vector2& v)
+{
+  m[index] = v.x;
+  m[index + 2] = v.y;
+}
+
+inline void Matrix2::setColumn(int index, const float col[2])
+{
+  m[index * 2] = col[0];
+  m[index * 2 + 1] = col[1];
+}
+
+inline void Matrix2::setColumn(int index, const Vector2& v)
+{
+  m[index * 2] = v.x;
+  m[index * 2 + 1] = v.y;
+}
+
+inline const float* Matrix2::get() const { return m; }
+
+inline Matrix2& Matrix2::identity()
+{
+  m[0] = m[3] = 1.0f;
+  m[1] = m[2] = 0.0f;
+  return *this;
+}
+
+inline Matrix2 Matrix2::operator+(const Matrix2& rhs) const
+{
+  return Matrix2(m[0] + rhs[0], m[1] + rhs[1], m[2] + rhs[2], m[3] + rhs[3]);
+}
+
+inline Matrix2 Matrix2::operator-(const Matrix2& rhs) const
+{
+  return Matrix2(m[0] - rhs[0], m[1] - rhs[1], m[2] - rhs[2], m[3] - rhs[3]);
+}
+
+inline Matrix2& Matrix2::operator+=(const Matrix2& rhs)
+{
+  m[0] += rhs[0];
+  m[1] += rhs[1];
+  m[2] += rhs[2];
+  m[3] += rhs[3];
+  return *this;
+}
+
+inline Matrix2& Matrix2::operator-=(const Matrix2& rhs)
+{
+  m[0] -= rhs[0];
+  m[1] -= rhs[1];
+  m[2] -= rhs[2];
+  m[3] -= rhs[3];
+  return *this;
+}
+
+inline Vector2 Matrix2::operator*(const Vector2& rhs) const
+{
+  return Vector2(m[0] * rhs.x + m[2] * rhs.y, m[1] * rhs.x + m[3] * rhs.y);
+}
+
+inline Matrix2 Matrix2::operator*(const Matrix2& rhs) const
+{
+  return Matrix2(m[0] * rhs[0] + m[2] * rhs[1], m[1] * rhs[0] + m[3] * rhs[1], m[0] * rhs[2] + m[2] * rhs[3],
+                 m[1] * rhs[2] + m[3] * rhs[3]);
+}
+
+inline Matrix2& Matrix2::operator*=(const Matrix2& rhs)
+{
+  *this = *this * rhs;
+  return *this;
+}
+
+inline bool Matrix2::operator==(const Matrix2& rhs) const
+{
+  return (m[0] == rhs[0]) && (m[1] == rhs[1]) && (m[2] == rhs[2]) && (m[3] == rhs[3]);
+}
+
+inline bool Matrix2::operator!=(const Matrix2& rhs) const
+{
+  return (m[0] != rhs[0]) || (m[1] != rhs[1]) || (m[2] != rhs[2]) || (m[3] != rhs[3]);
+}
+
+inline float Matrix2::operator[](int index) const { return m[index]; }
+
+inline float& Matrix2::operator[](int index) { return m[index]; }
+
+inline Matrix2 operator-(const Matrix2& rhs) { return Matrix2(-rhs[0], -rhs[1], -rhs[2], -rhs[3]); }
+
+inline Matrix2 operator*(float s, const Matrix2& rhs)
+{
+  return Matrix2(s * rhs[0], s * rhs[1], s * rhs[2], s * rhs[3]);
+}
+
+inline Vector2 operator*(const Vector2& v, const Matrix2& rhs)
+{
+  return Vector2(v.x * rhs[0] + v.y * rhs[1], v.x * rhs[2] + v.y * rhs[3]);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Matrix2& m)
+{
+  os << std::fixed << std::setprecision(5);
+  os << "[" << std::setw(10) << m[0] << " " << std::setw(10) << m[2] << "]\n"
+     << "[" << std::setw(10) << m[1] << " " << std::setw(10) << m[3] << "]\n";
+  os << std::resetiosflags(std::ios_base::fixed | std::ios_base::floatfield);
+  return os;
+}
+// END OF MATRIX2 INLINE //////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////
+// inline functions for Matrix3
+///////////////////////////////////////////////////////////////////////////
+inline Matrix3::Matrix3()
+{
+  // initially identity matrix
+  identity();
+}
+
+inline Matrix3::Matrix3(const float src[9]) { set(src); }
+
+inline Matrix3::Matrix3(float m0, float m1, float m2, float m3, float m4, float m5, float m6, float m7,
+                        float m8)
+{
+  set(m0, m1, m2, m3, m4, m5, m6, m7, m8);
+}
+
+inline void Matrix3::set(const float src[9])
+{
+  m[0] = src[0];
+  m[1] = src[1];
+  m[2] = src[2];
+  m[3] = src[3];
+  m[4] = src[4];
+  m[5] = src[5];
+  m[6] = src[6];
+  m[7] = src[7];
+  m[8] = src[8];
+}
+
+inline void Matrix3::set(float m0, float m1, float m2, float m3, float m4, float m5, float m6, float m7,
+                         float m8)
+{
+  m[0] = m0;
+  m[1] = m1;
+  m[2] = m2;
+  m[3] = m3;
+  m[4] = m4;
+  m[5] = m5;
+  m[6] = m6;
+  m[7] = m7;
+  m[8] = m8;
+}
+
+inline void Matrix3::setRow(int index, const float row[3])
+{
+  m[index] = row[0];
+  m[index + 3] = row[1];
+  m[index + 6] = row[2];
+}
+
+inline void Matrix3::setRow(int index, const Vector3& v)
+{
+  m[index] = v.x;
+  m[index + 3] = v.y;
+  m[index + 6] = v.z;
+}
+
+inline void Matrix3::setColumn(int index, const float col[3])
+{
+  m[index * 3] = col[0];
+  m[index * 3 + 1] = col[1];
+  m[index * 3 + 2] = col[2];
+}
+
+inline void Matrix3::setColumn(int index, const Vector3& v)
+{
+  m[index * 3] = v.x;
+  m[index * 3 + 1] = v.y;
+  m[index * 3 + 2] = v.z;
+}
+
+inline const float* Matrix3::get() const { return m; }
+
+inline Matrix3& Matrix3::identity()
+{
+  m[0] = m[4] = m[8] = 1.0f;
+  m[1] = m[2] = m[3] = m[5] = m[6] = m[7] = 0.0f;
+  return *this;
+}
+
+inline Matrix3 Matrix3::operator+(const Matrix3& rhs) const
+{
+  return Matrix3(m[0] + rhs[0], m[1] + rhs[1], m[2] + rhs[2], m[3] + rhs[3], m[4] + rhs[4], m[5] + rhs[5],
+                 m[6] + rhs[6], m[7] + rhs[7], m[8] + rhs[8]);
+}
+
+inline Matrix3 Matrix3::operator-(const Matrix3& rhs) const
+{
+  return Matrix3(m[0] - rhs[0], m[1] - rhs[1], m[2] - rhs[2], m[3] - rhs[3], m[4] - rhs[4], m[5] - rhs[5],
+                 m[6] - rhs[6], m[7] - rhs[7], m[8] - rhs[8]);
+}
+
+inline Matrix3& Matrix3::operator+=(const Matrix3& rhs)
+{
+  m[0] += rhs[0];
+  m[1] += rhs[1];
+  m[2] += rhs[2];
+  m[3] += rhs[3];
+  m[4] += rhs[4];
+  m[5] += rhs[5];
+  m[6] += rhs[6];
+  m[7] += rhs[7];
+  m[8] += rhs[8];
+  return *this;
+}
+
+inline Matrix3& Matrix3::operator-=(const Matrix3& rhs)
+{
+  m[0] -= rhs[0];
+  m[1] -= rhs[1];
+  m[2] -= rhs[2];
+  m[3] -= rhs[3];
+  m[4] -= rhs[4];
+  m[5] -= rhs[5];
+  m[6] -= rhs[6];
+  m[7] -= rhs[7];
+  m[8] -= rhs[8];
+  return *this;
+}
+
+inline Vector3 Matrix3::operator*(const Vector3& rhs) const
+{
+  return Vector3(m[0] * rhs.x + m[3] * rhs.y + m[6] * rhs.z, m[1] * rhs.x + m[4] * rhs.y + m[7] * rhs.z,
+                 m[2] * rhs.x + m[5] * rhs.y + m[8] * rhs.z);
+}
+
+inline Matrix3 Matrix3::operator*(const Matrix3& rhs) const
+{
+  return Matrix3(m[0] * rhs[0] + m[3] * rhs[1] + m[6] * rhs[2], m[1] * rhs[0] + m[4] * rhs[1] + m[7] * rhs[2],
+                 m[2] * rhs[0] + m[5] * rhs[1] + m[8] * rhs[2], m[0] * rhs[3] + m[3] * rhs[4] + m[6] * rhs[5],
+                 m[1] * rhs[3] + m[4] * rhs[4] + m[7] * rhs[5], m[2] * rhs[3] + m[5] * rhs[4] + m[8] * rhs[5],
+                 m[0] * rhs[6] + m[3] * rhs[7] + m[6] * rhs[8], m[1] * rhs[6] + m[4] * rhs[7] + m[7] * rhs[8],
+                 m[2] * rhs[6] + m[5] * rhs[7] + m[8] * rhs[8]);
+}
+
+inline Matrix3& Matrix3::operator*=(const Matrix3& rhs)
+{
+  *this = *this * rhs;
+  return *this;
+}
+
+inline bool Matrix3::operator==(const Matrix3& rhs) const
+{
+  return (m[0] == rhs[0]) && (m[1] == rhs[1]) && (m[2] == rhs[2]) && (m[3] == rhs[3]) && (m[4] == rhs[4]) &&
+         (m[5] == rhs[5]) && (m[6] == rhs[6]) && (m[7] == rhs[7]) && (m[8] == rhs[8]);
+}
+
+inline bool Matrix3::operator!=(const Matrix3& rhs) const
+{
+  return (m[0] != rhs[0]) || (m[1] != rhs[1]) || (m[2] != rhs[2]) || (m[3] != rhs[3]) || (m[4] != rhs[4]) ||
+         (m[5] != rhs[5]) || (m[6] != rhs[6]) || (m[7] != rhs[7]) || (m[8] != rhs[8]);
+}
+
+inline float Matrix3::operator[](int index) const { return m[index]; }
+
+inline float& Matrix3::operator[](int index) { return m[index]; }
+
+inline Matrix3 operator-(const Matrix3& rhs)
+{
+  return Matrix3(-rhs[0], -rhs[1], -rhs[2], -rhs[3], -rhs[4], -rhs[5], -rhs[6], -rhs[7], -rhs[8]);
+}
+
+inline Matrix3 operator*(float s, const Matrix3& rhs)
+{
+  return Matrix3(s * rhs[0], s * rhs[1], s * rhs[2], s * rhs[3], s * rhs[4], s * rhs[5], s * rhs[6],
+                 s * rhs[7], s * rhs[8]);
+}
+
+inline Vector3 operator*(const Vector3& v, const Matrix3& m)
+{
+  return Vector3(v.x * m[0] + v.y * m[1] + v.z * m[2], v.x * m[3] + v.y * m[4] + v.z * m[5],
+                 v.x * m[6] + v.y * m[7] + v.z * m[8]);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Matrix3& m)
+{
+  os << std::fixed << std::setprecision(5);
+  os << "[" << std::setw(10) << m[0] << " " << std::setw(10) << m[3] << " " << std::setw(10) << m[6] << "]\n"
+     << "[" << std::setw(10) << m[1] << " " << std::setw(10) << m[4] << " " << std::setw(10) << m[7] << "]\n"
+     << "[" << std::setw(10) << m[2] << " " << std::setw(10) << m[5] << " " << std::setw(10) << m[8] << "]\n";
+  os << std::resetiosflags(std::ios_base::fixed | std::ios_base::floatfield);
+  return os;
+}
+// END OF MATRIX3 INLINE //////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////
+// inline functions for Matrix4
+///////////////////////////////////////////////////////////////////////////
+inline Matrix4::Matrix4()
+{
+  // initially identity matrix
+  identity();
+}
+
+inline Matrix4::Matrix4(const float src[16]) { set(src); }
+
+inline Matrix4::Matrix4(float m00, float m01, float m02, float m03, float m04, float m05, float m06,
+                        float m07, float m08, float m09, float m10, float m11, float m12, float m13,
+                        float m14, float m15)
+{
+  set(m00, m01, m02, m03, m04, m05, m06, m07, m08, m09, m10, m11, m12, m13, m14, m15);
+}
+
+inline void Matrix4::set(const float src[16])
+{
+  m[0] = src[0];
+  m[1] = src[1];
+  m[2] = src[2];
+  m[3] = src[3];
+  m[4] = src[4];
+  m[5] = src[5];
+  m[6] = src[6];
+  m[7] = src[7];
+  m[8] = src[8];
+  m[9] = src[9];
+  m[10] = src[10];
+  m[11] = src[11];
+  m[12] = src[12];
+  m[13] = src[13];
+  m[14] = src[14];
+  m[15] = src[15];
+}
+
+inline void Matrix4::set(float m00, float m01, float m02, float m03, float m04, float m05, float m06,
+                         float m07, float m08, float m09, float m10, float m11, float m12, float m13,
+                         float m14, float m15)
+{
+  m[0] = m00;
+  m[1] = m01;
+  m[2] = m02;
+  m[3] = m03;
+  m[4] = m04;
+  m[5] = m05;
+  m[6] = m06;
+  m[7] = m07;
+  m[8] = m08;
+  m[9] = m09;
+  m[10] = m10;
+  m[11] = m11;
+  m[12] = m12;
+  m[13] = m13;
+  m[14] = m14;
+  m[15] = m15;
+}
+
+inline void Matrix4::setRow(int index, const float row[4])
+{
+  m[index] = row[0];
+  m[index + 4] = row[1];
+  m[index + 8] = row[2];
+  m[index + 12] = row[3];
+}
+
+inline void Matrix4::setRow(int index, const Vector4& v)
+{
+  m[index] = v.x;
+  m[index + 4] = v.y;
+  m[index + 8] = v.z;
+  m[index + 12] = v.w;
+}
+
+inline void Matrix4::setRow(int index, const Vector3& v)
+{
+  m[index] = v.x;
+  m[index + 4] = v.y;
+  m[index + 8] = v.z;
+}
+
+inline void Matrix4::setColumn(int index, const float col[4])
+{
+  m[index * 4] = col[0];
+  m[index * 4 + 1] = col[1];
+  m[index * 4 + 2] = col[2];
+  m[index * 4 + 3] = col[3];
+}
+
+inline void Matrix4::setColumn(int index, const Vector4& v)
+{
+  m[index * 4] = v.x;
+  m[index * 4 + 1] = v.y;
+  m[index * 4 + 2] = v.z;
+  m[index * 4 + 3] = v.w;
+}
+
+inline void Matrix4::setColumn(int index, const Vector3& v)
+{
+  m[index * 4] = v.x;
+  m[index * 4 + 1] = v.y;
+  m[index * 4 + 2] = v.z;
+}
+
+inline const float* Matrix4::get() const { return m; }
+
+inline const float* Matrix4::getTranspose()
+{
+  tm[0] = m[0];
+  tm[1] = m[4];
+  tm[2] = m[8];
+  tm[3] = m[12];
+  tm[4] = m[1];
+  tm[5] = m[5];
+  tm[6] = m[9];
+  tm[7] = m[13];
+  tm[8] = m[2];
+  tm[9] = m[6];
+  tm[10] = m[10];
+  tm[11] = m[14];
+  tm[12] = m[3];
+  tm[13] = m[7];
+  tm[14] = m[11];
+  tm[15] = m[15];
+  return tm;
+}
+
+inline Matrix4& Matrix4::identity()
+{
+  m[0] = m[5] = m[10] = m[15] = 1.0f;
+  m[1] = m[2] = m[3] = m[4] = m[6] = m[7] = m[8] = m[9] = m[11] = m[12] = m[13] = m[14] = 0.0f;
+  return *this;
+}
+
+inline Matrix4 Matrix4::operator+(const Matrix4& rhs) const
+{
+  return Matrix4(m[0] + rhs[0], m[1] + rhs[1], m[2] + rhs[2], m[3] + rhs[3], m[4] + rhs[4], m[5] + rhs[5],
+                 m[6] + rhs[6], m[7] + rhs[7], m[8] + rhs[8], m[9] + rhs[9], m[10] + rhs[10], m[11] + rhs[11],
+                 m[12] + rhs[12], m[13] + rhs[13], m[14] + rhs[14], m[15] + rhs[15]);
+}
+
+inline Matrix4 Matrix4::operator-(const Matrix4& rhs) const
+{
+  return Matrix4(m[0] - rhs[0], m[1] - rhs[1], m[2] - rhs[2], m[3] - rhs[3], m[4] - rhs[4], m[5] - rhs[5],
+                 m[6] - rhs[6], m[7] - rhs[7], m[8] - rhs[8], m[9] - rhs[9], m[10] - rhs[10], m[11] - rhs[11],
+                 m[12] - rhs[12], m[13] - rhs[13], m[14] - rhs[14], m[15] - rhs[15]);
+}
+
+inline Matrix4& Matrix4::operator+=(const Matrix4& rhs)
+{
+  m[0] += rhs[0];
+  m[1] += rhs[1];
+  m[2] += rhs[2];
+  m[3] += rhs[3];
+  m[4] += rhs[4];
+  m[5] += rhs[5];
+  m[6] += rhs[6];
+  m[7] += rhs[7];
+  m[8] += rhs[8];
+  m[9] += rhs[9];
+  m[10] += rhs[10];
+  m[11] += rhs[11];
+  m[12] += rhs[12];
+  m[13] += rhs[13];
+  m[14] += rhs[14];
+  m[15] += rhs[15];
+  return *this;
+}
+
+inline Matrix4& Matrix4::operator-=(const Matrix4& rhs)
+{
+  m[0] -= rhs[0];
+  m[1] -= rhs[1];
+  m[2] -= rhs[2];
+  m[3] -= rhs[3];
+  m[4] -= rhs[4];
+  m[5] -= rhs[5];
+  m[6] -= rhs[6];
+  m[7] -= rhs[7];
+  m[8] -= rhs[8];
+  m[9] -= rhs[9];
+  m[10] -= rhs[10];
+  m[11] -= rhs[11];
+  m[12] -= rhs[12];
+  m[13] -= rhs[13];
+  m[14] -= rhs[14];
+  m[15] -= rhs[15];
+  return *this;
+}
+
+inline Vector4 Matrix4::operator*(const Vector4& rhs) const
+{
+  return Vector4(m[0] * rhs.x + m[4] * rhs.y + m[8] * rhs.z + m[12] * rhs.w,
+                 m[1] * rhs.x + m[5] * rhs.y + m[9] * rhs.z + m[13] * rhs.w,
+                 m[2] * rhs.x + m[6] * rhs.y + m[10] * rhs.z + m[14] * rhs.w,
+                 m[3] * rhs.x + m[7] * rhs.y + m[11] * rhs.z + m[15] * rhs.w);
+}
+
+inline Vector3 Matrix4::operator*(const Vector3& rhs) const
+{
+  return Vector3(m[0] * rhs.x + m[4] * rhs.y + m[8] * rhs.z, m[1] * rhs.x + m[5] * rhs.y + m[9] * rhs.z,
+                 m[2] * rhs.x + m[6] * rhs.y + m[10] * rhs.z);
+}
+
+inline Matrix4 Matrix4::operator*(const Matrix4& n) const
+{
+  return Matrix4(m[0] * n[0] + m[4] * n[1] + m[8] * n[2] + m[12] * n[3],
+                 m[1] * n[0] + m[5] * n[1] + m[9] * n[2] + m[13] * n[3],
+                 m[2] * n[0] + m[6] * n[1] + m[10] * n[2] + m[14] * n[3],
+                 m[3] * n[0] + m[7] * n[1] + m[11] * n[2] + m[15] * n[3],
+                 m[0] * n[4] + m[4] * n[5] + m[8] * n[6] + m[12] * n[7],
+                 m[1] * n[4] + m[5] * n[5] + m[9] * n[6] + m[13] * n[7],
+                 m[2] * n[4] + m[6] * n[5] + m[10] * n[6] + m[14] * n[7],
+                 m[3] * n[4] + m[7] * n[5] + m[11] * n[6] + m[15] * n[7],
+                 m[0] * n[8] + m[4] * n[9] + m[8] * n[10] + m[12] * n[11],
+                 m[1] * n[8] + m[5] * n[9] + m[9] * n[10] + m[13] * n[11],
+                 m[2] * n[8] + m[6] * n[9] + m[10] * n[10] + m[14] * n[11],
+                 m[3] * n[8] + m[7] * n[9] + m[11] * n[10] + m[15] * n[11],
+                 m[0] * n[12] + m[4] * n[13] + m[8] * n[14] + m[12] * n[15],
+                 m[1] * n[12] + m[5] * n[13] + m[9] * n[14] + m[13] * n[15],
+                 m[2] * n[12] + m[6] * n[13] + m[10] * n[14] + m[14] * n[15],
+                 m[3] * n[12] + m[7] * n[13] + m[11] * n[14] + m[15] * n[15]);
+}
+
+inline Matrix4& Matrix4::operator*=(const Matrix4& rhs)
+{
+  *this = *this * rhs;
+  return *this;
+}
+
+inline bool Matrix4::operator==(const Matrix4& n) const
+{
+  return (m[0] == n[0]) && (m[1] == n[1]) && (m[2] == n[2]) && (m[3] == n[3]) && (m[4] == n[4]) &&
+         (m[5] == n[5]) && (m[6] == n[6]) && (m[7] == n[7]) && (m[8] == n[8]) && (m[9] == n[9]) &&
+         (m[10] == n[10]) && (m[11] == n[11]) && (m[12] == n[12]) && (m[13] == n[13]) && (m[14] == n[14]) &&
+         (m[15] == n[15]);
+}
+
+inline bool Matrix4::operator!=(const Matrix4& n) const
+{
+  return (m[0] != n[0]) || (m[1] != n[1]) || (m[2] != n[2]) || (m[3] != n[3]) || (m[4] != n[4]) ||
+         (m[5] != n[5]) || (m[6] != n[6]) || (m[7] != n[7]) || (m[8] != n[8]) || (m[9] != n[9]) ||
+         (m[10] != n[10]) || (m[11] != n[11]) || (m[12] != n[12]) || (m[13] != n[13]) || (m[14] != n[14]) ||
+         (m[15] != n[15]);
+}
+
+inline float Matrix4::operator[](int index) const { return m[index]; }
+
+inline float& Matrix4::operator[](int index) { return m[index]; }
+
+inline Matrix4 operator-(const Matrix4& rhs)
+{
+  return Matrix4(-rhs[0], -rhs[1], -rhs[2], -rhs[3], -rhs[4], -rhs[5], -rhs[6], -rhs[7], -rhs[8], -rhs[9],
+                 -rhs[10], -rhs[11], -rhs[12], -rhs[13], -rhs[14], -rhs[15]);
+}
+
+inline Matrix4 operator*(float s, const Matrix4& rhs)
+{
+  return Matrix4(s * rhs[0], s * rhs[1], s * rhs[2], s * rhs[3], s * rhs[4], s * rhs[5], s * rhs[6],
+                 s * rhs[7], s * rhs[8], s * rhs[9], s * rhs[10], s * rhs[11], s * rhs[12], s * rhs[13],
+                 s * rhs[14], s * rhs[15]);
+}
+
+inline Vector4 operator*(const Vector4& v, const Matrix4& m)
+{
+  return Vector4(v.x * m[0] + v.y * m[1] + v.z * m[2] + v.w * m[3],
+                 v.x * m[4] + v.y * m[5] + v.z * m[6] + v.w * m[7],
+                 v.x * m[8] + v.y * m[9] + v.z * m[10] + v.w * m[11],
+                 v.x * m[12] + v.y * m[13] + v.z * m[14] + v.w * m[15]);
+}
+
+inline Vector3 operator*(const Vector3& v, const Matrix4& m)
+{
+  return Vector3(v.x * m[0] + v.y * m[1] + v.z * m[2], v.x * m[4] + v.y * m[5] + v.z * m[6],
+                 v.x * m[8] + v.y * m[9] + v.z * m[10]);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Matrix4& m)
+{
+  os << std::fixed << std::setprecision(5);
+  os << "[" << std::setw(10) << m[0] << " " << std::setw(10) << m[4] << " " << std::setw(10) << m[8] << " "
+     << std::setw(10) << m[12] << "]\n"
+     << "[" << std::setw(10) << m[1] << " " << std::setw(10) << m[5] << " " << std::setw(10) << m[9] << " "
+     << std::setw(10) << m[13] << "]\n"
+     << "[" << std::setw(10) << m[2] << " " << std::setw(10) << m[6] << " " << std::setw(10) << m[10] << " "
+     << std::setw(10) << m[14] << "]\n"
+     << "[" << std::setw(10) << m[3] << " " << std::setw(10) << m[7] << " " << std::setw(10) << m[11] << " "
+     << std::setw(10) << m[15] << "]\n";
+  os << std::resetiosflags(std::ios_base::fixed | std::ios_base::floatfield);
+  return os;
+}
+// END OF MATRIX4 INLINE //////////////////////////////////////////////////////
+#endif

--- a/include/z11/vectors.h
+++ b/include/z11/vectors.h
@@ -1,0 +1,562 @@
+///////////////////////////////////////////////////////////////////////////////
+// Vectors.h
+// =========
+// 2D/3D/4D vectors
+//
+//  AUTHOR: Song Ho Ahn (song.ahn@gmail.com)
+// CREATED: 2007-02-14
+// UPDATED: 2013-01-20
+//
+// Copyright (C) 2007-2013 Song Ho Ahn
+///////////////////////////////////////////////////////////////////////////////
+
+#ifndef LIBZ11_VECTORS_H
+#define LIBZ11_VECTORS_H
+
+#include <cmath>
+#include <iostream>
+
+///////////////////////////////////////////////////////////////////////////////
+// 2D vector
+///////////////////////////////////////////////////////////////////////////////
+struct Vector2 {
+  float x;
+  float y;
+
+  // ctors
+  Vector2() : x(0), y(0){};
+  Vector2(float x, float y) : x(x), y(y){};
+
+  // utils functions
+  void set(float x, float y);
+  float length() const;                           //
+  float distance(const Vector2& vec) const;       // distance between two vectors
+  Vector2& normalize();                           //
+  float dot(const Vector2& vec) const;            // dot product
+  bool equal(const Vector2& vec, float e) const;  // compare with epsilon
+
+  // operators
+  Vector2 operator-() const;                    // unary operator (negate)
+  Vector2 operator+(const Vector2& rhs) const;  // add rhs
+  Vector2 operator-(const Vector2& rhs) const;  // subtract rhs
+  Vector2& operator+=(const Vector2& rhs);      // add rhs and update this object
+  Vector2& operator-=(const Vector2& rhs);      // subtract rhs and update this object
+  Vector2 operator*(const float scale) const;   // scale
+  Vector2 operator*(const Vector2& rhs) const;  // multiply each element
+  Vector2& operator*=(const float scale);       // scale and update this object
+  Vector2& operator*=(const Vector2& rhs);      // multiply each element and update this object
+  Vector2 operator/(const float scale) const;   // inverse scale
+  Vector2& operator/=(const float scale);       // scale and update this object
+  bool operator==(const Vector2& rhs) const;    // exact compare, no epsilon
+  bool operator!=(const Vector2& rhs) const;    // exact compare, no epsilon
+  bool operator<(const Vector2& rhs) const;     // comparison for sort
+  float operator[](int index) const;            // subscript operator v[0], v[1]
+  float& operator[](int index);                 // subscript operator v[0], v[1]
+
+  friend Vector2 operator*(const float a, const Vector2 vec);
+  friend std::ostream& operator<<(std::ostream& os, const Vector2& vec);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// 3D vector
+///////////////////////////////////////////////////////////////////////////////
+struct Vector3 {
+  float x;
+  float y;
+  float z;
+
+  // ctors
+  Vector3() : x(0), y(0), z(0){};
+  Vector3(float x, float y, float z) : x(x), y(y), z(z){};
+
+  // utils functions
+  void set(float x, float y, float z);
+  float length() const;                           //
+  float distance(const Vector3& vec) const;       // distance between two vectors
+  Vector3& normalize();                           //
+  float dot(const Vector3& vec) const;            // dot product
+  Vector3 cross(const Vector3& vec) const;        // cross product
+  bool equal(const Vector3& vec, float e) const;  // compare with epsilon
+
+  // operators
+  Vector3 operator-() const;                    // unary operator (negate)
+  Vector3 operator+(const Vector3& rhs) const;  // add rhs
+  Vector3 operator-(const Vector3& rhs) const;  // subtract rhs
+  Vector3& operator+=(const Vector3& rhs);      // add rhs and update this object
+  Vector3& operator-=(const Vector3& rhs);      // subtract rhs and update this object
+  Vector3 operator*(const float scale) const;   // scale
+  Vector3 operator*(const Vector3& rhs) const;  // multiplay each element
+  Vector3& operator*=(const float scale);       // scale and update this object
+  Vector3& operator*=(const Vector3& rhs);      // product each element and update this object
+  Vector3 operator/(const float scale) const;   // inverse scale
+  Vector3& operator/=(const float scale);       // scale and update this object
+  bool operator==(const Vector3& rhs) const;    // exact compare, no epsilon
+  bool operator!=(const Vector3& rhs) const;    // exact compare, no epsilon
+  bool operator<(const Vector3& rhs) const;     // comparison for sort
+  float operator[](int index) const;            // subscript operator v[0], v[1]
+  float& operator[](int index);                 // subscript operator v[0], v[1]
+
+  friend Vector3 operator*(const float a, const Vector3 vec);
+  friend std::ostream& operator<<(std::ostream& os, const Vector3& vec);
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// 4D vector
+///////////////////////////////////////////////////////////////////////////////
+struct Vector4 {
+  float x;
+  float y;
+  float z;
+  float w;
+
+  // ctors
+  Vector4() : x(0), y(0), z(0), w(0){};
+  Vector4(float x, float y, float z, float w) : x(x), y(y), z(z), w(w){};
+
+  // utils functions
+  void set(float x, float y, float z, float w);
+  float length() const;                           //
+  float distance(const Vector4& vec) const;       // distance between two vectors
+  Vector4& normalize();                           //
+  float dot(const Vector4& vec) const;            // dot product
+  bool equal(const Vector4& vec, float e) const;  // compare with epsilon
+
+  // operators
+  Vector4 operator-() const;                    // unary operator (negate)
+  Vector4 operator+(const Vector4& rhs) const;  // add rhs
+  Vector4 operator-(const Vector4& rhs) const;  // subtract rhs
+  Vector4& operator+=(const Vector4& rhs);      // add rhs and update this object
+  Vector4& operator-=(const Vector4& rhs);      // subtract rhs and update this object
+  Vector4 operator*(const float scale) const;   // scale
+  Vector4 operator*(const Vector4& rhs) const;  // multiply each element
+  Vector4& operator*=(const float scale);       // scale and update this object
+  Vector4& operator*=(const Vector4& rhs);      // multiply each element and update this object
+  Vector4 operator/(const float scale) const;   // inverse scale
+  Vector4& operator/=(const float scale);       // scale and update this object
+  bool operator==(const Vector4& rhs) const;    // exact compare, no epsilon
+  bool operator!=(const Vector4& rhs) const;    // exact compare, no epsilon
+  bool operator<(const Vector4& rhs) const;     // comparison for sort
+  float operator[](int index) const;            // subscript operator v[0], v[1]
+  float& operator[](int index);                 // subscript operator v[0], v[1]
+
+  friend Vector4 operator*(const float a, const Vector4 vec);
+  friend std::ostream& operator<<(std::ostream& os, const Vector4& vec);
+};
+
+// fast math routines from Doom3 SDK
+inline float invSqrt(float x)
+{
+  float xhalf = 0.5f * x;
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+  int i = *(int*)&x;          // get bits for floating value
+  i = 0x5f3759df - (i >> 1);  // gives initial guess
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+  x = *(float*)&i;                 // convert bits back to float
+  x = x * (1.5f - xhalf * x * x);  // Newton step
+  return x;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// inline functions for Vector2
+///////////////////////////////////////////////////////////////////////////////
+inline Vector2 Vector2::operator-() const { return Vector2(-x, -y); }
+
+inline Vector2 Vector2::operator+(const Vector2& rhs) const { return Vector2(x + rhs.x, y + rhs.y); }
+
+inline Vector2 Vector2::operator-(const Vector2& rhs) const { return Vector2(x - rhs.x, y - rhs.y); }
+
+inline Vector2& Vector2::operator+=(const Vector2& rhs)
+{
+  x += rhs.x;
+  y += rhs.y;
+  return *this;
+}
+
+inline Vector2& Vector2::operator-=(const Vector2& rhs)
+{
+  x -= rhs.x;
+  y -= rhs.y;
+  return *this;
+}
+
+inline Vector2 Vector2::operator*(const float a) const { return Vector2(x * a, y * a); }
+
+inline Vector2 Vector2::operator*(const Vector2& rhs) const { return Vector2(x * rhs.x, y * rhs.y); }
+
+inline Vector2& Vector2::operator*=(const float a)
+{
+  x *= a;
+  y *= a;
+  return *this;
+}
+
+inline Vector2& Vector2::operator*=(const Vector2& rhs)
+{
+  x *= rhs.x;
+  y *= rhs.y;
+  return *this;
+}
+
+inline Vector2 Vector2::operator/(const float a) const { return Vector2(x / a, y / a); }
+
+inline Vector2& Vector2::operator/=(const float a)
+{
+  x /= a;
+  y /= a;
+  return *this;
+}
+
+inline bool Vector2::operator==(const Vector2& rhs) const { return (x == rhs.x) && (y == rhs.y); }
+
+inline bool Vector2::operator!=(const Vector2& rhs) const { return (x != rhs.x) || (y != rhs.y); }
+
+inline bool Vector2::operator<(const Vector2& rhs) const
+{
+  if (x < rhs.x) return true;
+  if (x > rhs.x) return false;
+  if (y < rhs.y) return true;
+  if (y > rhs.y) return false;
+  return false;
+}
+
+inline float Vector2::operator[](int index) const { return (&x)[index]; }
+
+inline float& Vector2::operator[](int index) { return (&x)[index]; }
+
+inline void Vector2::set(float x_, float y_)
+{
+  this->x = x_;
+  this->y = y_;
+}
+
+inline float Vector2::length() const { return sqrtf(x * x + y * y); }
+
+inline float Vector2::distance(const Vector2& vec) const
+{
+  return sqrtf((vec.x - x) * (vec.x - x) + (vec.y - y) * (vec.y - y));
+}
+
+inline Vector2& Vector2::normalize()
+{
+  //@@const float EPSILON = 0.000001f;
+  float xxyy = x * x + y * y;
+  //@@if(xxyy < EPSILON)
+  //@@    return *this;
+
+  // float invLength = invSqrt(xxyy);
+  float invLength = 1.0f / sqrtf(xxyy);
+  x *= invLength;
+  y *= invLength;
+  return *this;
+}
+
+inline float Vector2::dot(const Vector2& rhs) const { return (x * rhs.x + y * rhs.y); }
+
+inline bool Vector2::equal(const Vector2& rhs, float epsilon) const
+{
+  return fabs(x - rhs.x) < epsilon && fabs(y - rhs.y) < epsilon;
+}
+
+inline Vector2 operator*(const float a, const Vector2 vec) { return Vector2(a * vec.x, a * vec.y); }
+
+inline std::ostream& operator<<(std::ostream& os, const Vector2& vec)
+{
+  os << "(" << vec.x << ", " << vec.y << ")";
+  return os;
+}
+// END OF VECTOR2 /////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// inline functions for Vector3
+///////////////////////////////////////////////////////////////////////////////
+inline Vector3 Vector3::operator-() const { return Vector3(-x, -y, -z); }
+
+inline Vector3 Vector3::operator+(const Vector3& rhs) const
+{
+  return Vector3(x + rhs.x, y + rhs.y, z + rhs.z);
+}
+
+inline Vector3 Vector3::operator-(const Vector3& rhs) const
+{
+  return Vector3(x - rhs.x, y - rhs.y, z - rhs.z);
+}
+
+inline Vector3& Vector3::operator+=(const Vector3& rhs)
+{
+  x += rhs.x;
+  y += rhs.y;
+  z += rhs.z;
+  return *this;
+}
+
+inline Vector3& Vector3::operator-=(const Vector3& rhs)
+{
+  x -= rhs.x;
+  y -= rhs.y;
+  z -= rhs.z;
+  return *this;
+}
+
+inline Vector3 Vector3::operator*(const float a) const { return Vector3(x * a, y * a, z * a); }
+
+inline Vector3 Vector3::operator*(const Vector3& rhs) const
+{
+  return Vector3(x * rhs.x, y * rhs.y, z * rhs.z);
+}
+
+inline Vector3& Vector3::operator*=(const float a)
+{
+  x *= a;
+  y *= a;
+  z *= a;
+  return *this;
+}
+
+inline Vector3& Vector3::operator*=(const Vector3& rhs)
+{
+  x *= rhs.x;
+  y *= rhs.y;
+  z *= rhs.z;
+  return *this;
+}
+
+inline Vector3 Vector3::operator/(const float a) const { return Vector3(x / a, y / a, z / a); }
+
+inline Vector3& Vector3::operator/=(const float a)
+{
+  x /= a;
+  y /= a;
+  z /= a;
+  return *this;
+}
+
+inline bool Vector3::operator==(const Vector3& rhs) const
+{
+  return (x == rhs.x) && (y == rhs.y) && (z == rhs.z);
+}
+
+inline bool Vector3::operator!=(const Vector3& rhs) const
+{
+  return (x != rhs.x) || (y != rhs.y) || (z != rhs.z);
+}
+
+inline bool Vector3::operator<(const Vector3& rhs) const
+{
+  if (x < rhs.x) return true;
+  if (x > rhs.x) return false;
+  if (y < rhs.y) return true;
+  if (y > rhs.y) return false;
+  if (z < rhs.z) return true;
+  if (z > rhs.z) return false;
+  return false;
+}
+
+inline float Vector3::operator[](int index) const { return (&x)[index]; }
+
+inline float& Vector3::operator[](int index) { return (&x)[index]; }
+
+inline void Vector3::set(float x_, float y_, float z_)
+{
+  this->x = x_;
+  this->y = y_;
+  this->z = z_;
+}
+
+inline float Vector3::length() const { return sqrtf(x * x + y * y + z * z); }
+
+inline float Vector3::distance(const Vector3& vec) const
+{
+  return sqrtf((vec.x - x) * (vec.x - x) + (vec.y - y) * (vec.y - y) + (vec.z - z) * (vec.z - z));
+}
+
+inline Vector3& Vector3::normalize()
+{
+  //@@const float EPSILON = 0.000001f;
+  float xxyyzz = x * x + y * y + z * z;
+  //@@if(xxyyzz < EPSILON)
+  //@@    return *this; // do nothing if it is ~zero vector
+
+  // float invLength = invSqrt(xxyyzz);
+  float invLength = 1.0f / sqrtf(xxyyzz);
+  x *= invLength;
+  y *= invLength;
+  z *= invLength;
+  return *this;
+}
+
+inline float Vector3::dot(const Vector3& rhs) const { return (x * rhs.x + y * rhs.y + z * rhs.z); }
+
+inline Vector3 Vector3::cross(const Vector3& rhs) const
+{
+  return Vector3(y * rhs.z - z * rhs.y, z * rhs.x - x * rhs.z, x * rhs.y - y * rhs.x);
+}
+
+inline bool Vector3::equal(const Vector3& rhs, float epsilon) const
+{
+  return fabs(x - rhs.x) < epsilon && fabs(y - rhs.y) < epsilon && fabs(z - rhs.z) < epsilon;
+}
+
+inline Vector3 operator*(const float a, const Vector3 vec)
+{
+  return Vector3(a * vec.x, a * vec.y, a * vec.z);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Vector3& vec)
+{
+  os << "(" << vec.x << ", " << vec.y << ", " << vec.z << ")";
+  return os;
+}
+// END OF VECTOR3 /////////////////////////////////////////////////////////////
+
+///////////////////////////////////////////////////////////////////////////////
+// inline functions for Vector4
+///////////////////////////////////////////////////////////////////////////////
+inline Vector4 Vector4::operator-() const { return Vector4(-x, -y, -z, -w); }
+
+inline Vector4 Vector4::operator+(const Vector4& rhs) const
+{
+  return Vector4(x + rhs.x, y + rhs.y, z + rhs.z, w + rhs.w);
+}
+
+inline Vector4 Vector4::operator-(const Vector4& rhs) const
+{
+  return Vector4(x - rhs.x, y - rhs.y, z - rhs.z, w - rhs.w);
+}
+
+inline Vector4& Vector4::operator+=(const Vector4& rhs)
+{
+  x += rhs.x;
+  y += rhs.y;
+  z += rhs.z;
+  w += rhs.w;
+  return *this;
+}
+
+inline Vector4& Vector4::operator-=(const Vector4& rhs)
+{
+  x -= rhs.x;
+  y -= rhs.y;
+  z -= rhs.z;
+  w -= rhs.w;
+  return *this;
+}
+
+inline Vector4 Vector4::operator*(const float a) const { return Vector4(x * a, y * a, z * a, w * a); }
+
+inline Vector4 Vector4::operator*(const Vector4& rhs) const
+{
+  return Vector4(x * rhs.x, y * rhs.y, z * rhs.z, w * rhs.w);
+}
+
+inline Vector4& Vector4::operator*=(const float a)
+{
+  x *= a;
+  y *= a;
+  z *= a;
+  w *= a;
+  return *this;
+}
+
+inline Vector4& Vector4::operator*=(const Vector4& rhs)
+{
+  x *= rhs.x;
+  y *= rhs.y;
+  z *= rhs.z;
+  w *= rhs.w;
+  return *this;
+}
+
+inline Vector4 Vector4::operator/(const float a) const { return Vector4(x / a, y / a, z / a, w / a); }
+
+inline Vector4& Vector4::operator/=(const float a)
+{
+  x /= a;
+  y /= a;
+  z /= a;
+  w /= a;
+  return *this;
+}
+
+inline bool Vector4::operator==(const Vector4& rhs) const
+{
+  return (x == rhs.x) && (y == rhs.y) && (z == rhs.z) && (w == rhs.w);
+}
+
+inline bool Vector4::operator!=(const Vector4& rhs) const
+{
+  return (x != rhs.x) || (y != rhs.y) || (z != rhs.z) || (w != rhs.w);
+}
+
+inline bool Vector4::operator<(const Vector4& rhs) const
+{
+  if (x < rhs.x) return true;
+  if (x > rhs.x) return false;
+  if (y < rhs.y) return true;
+  if (y > rhs.y) return false;
+  if (z < rhs.z) return true;
+  if (z > rhs.z) return false;
+  if (w < rhs.w) return true;
+  if (w > rhs.w) return false;
+  return false;
+}
+
+inline float Vector4::operator[](int index) const { return (&x)[index]; }
+
+inline float& Vector4::operator[](int index) { return (&x)[index]; }
+
+inline void Vector4::set(float x_, float y_, float z_, float w_)
+{
+  this->x = x_;
+  this->y = y_;
+  this->z = z_;
+  this->w = w_;
+}
+
+inline float Vector4::length() const { return sqrtf(x * x + y * y + z * z + w * w); }
+
+inline float Vector4::distance(const Vector4& vec) const
+{
+  return sqrtf((vec.x - x) * (vec.x - x) + (vec.y - y) * (vec.y - y) + (vec.z - z) * (vec.z - z) +
+               (vec.w - w) * (vec.w - w));
+}
+
+inline Vector4& Vector4::normalize()
+{
+  // NOTE: leave w-component untouched
+  //@@const float EPSILON = 0.000001f;
+  float xxyyzz = x * x + y * y + z * z;
+  //@@if(xxyyzz < EPSILON)
+  //@@    return *this; // do nothing if it is zero vector
+
+  // float invLength = invSqrt(xxyyzz);
+  float invLength = 1.0f / sqrtf(xxyyzz);
+  x *= invLength;
+  y *= invLength;
+  z *= invLength;
+  return *this;
+}
+
+inline float Vector4::dot(const Vector4& rhs) const
+{
+  return (x * rhs.x + y * rhs.y + z * rhs.z + w * rhs.w);
+}
+
+inline bool Vector4::equal(const Vector4& rhs, float epsilon) const
+{
+  return fabs(x - rhs.x) < epsilon && fabs(y - rhs.y) < epsilon && fabs(z - rhs.z) < epsilon &&
+         fabs(w - rhs.w) < epsilon;
+}
+
+inline Vector4 operator*(const float a, const Vector4 vec)
+{
+  return Vector4(a * vec.x, a * vec.y, a * vec.z, a * vec.w);
+}
+
+inline std::ostream& operator<<(std::ostream& os, const Vector4& vec)
+{
+  os << "(" << vec.x << ", " << vec.y << ", " << vec.z << ", " << vec.w << ")";
+  return os;
+}
+// END OF VECTOR4 /////////////////////////////////////////////////////////////
+
+#endif

--- a/libz11/compositor.cc
+++ b/libz11/compositor.cc
@@ -13,13 +13,12 @@ Compositor* Compositor::Create()
   return nullptr;
 }
 
-Compositor::Compositor() : created_(false), display_(nullptr), loop_(nullptr)
+Compositor::Compositor() : created_(false), display_(nullptr), loop_(nullptr), render_block_list_(nullptr)
 {
   const char* socket;
   display_ = wl_display_create();
   loop_ = wl_display_get_event_loop(display_);
-
-  wl_list_init(&render_blocks_);
+  render_block_list_ = new List<RenderBlock>();
 
   ZCompositor* z_compositor = ZCompositor::Create(this);
   if (z_compositor == nullptr) return;
@@ -34,5 +33,7 @@ Compositor::Compositor() : created_(false), display_(nullptr), loop_(nullptr)
 }
 
 Compositor::~Compositor() { wl_display_destroy(display_); }
+
+void Compositor::PushRenderBlock(List<RenderBlock>* link) { render_block_list_->Insert(link); }
 
 }  // namespace z11

--- a/libz11/matrices.cc
+++ b/libz11/matrices.cc
@@ -1,0 +1,559 @@
+///////////////////////////////////////////////////////////////////////////////
+// Matrice.cpp
+// ===========
+// NxN Matrix Math classes
+//
+// The elements of the matrix are stored as column major order.
+// | 0 2 |    | 0 3 6 |    |  0  4  8 12 |
+// | 1 3 |    | 1 4 7 |    |  1  5  9 13 |
+//            | 2 5 8 |    |  2  6 10 14 |
+//                         |  3  7 11 15 |
+//
+//  AUTHOR: Song Ho Ahn (song.ahn@gmail.com)
+// CREATED: 2005-06-24
+// UPDATED: 2014-09-21
+//
+// Copyright (C) 2005 Song Ho Ahn
+///////////////////////////////////////////////////////////////////////////////
+
+#include <z11/matrices.h>
+
+#include <algorithm>
+#include <cmath>
+
+const float DEG2RAD = 3.141593f / 180;
+const float EPSILON = 0.00001f;
+
+///////////////////////////////////////////////////////////////////////////////
+// transpose 2x2 matrix
+///////////////////////////////////////////////////////////////////////////////
+Matrix2& Matrix2::transpose()
+{
+  std::swap(m[1], m[2]);
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// return the determinant of 2x2 matrix
+///////////////////////////////////////////////////////////////////////////////
+float Matrix2::getDeterminant() { return m[0] * m[3] - m[1] * m[2]; }
+
+///////////////////////////////////////////////////////////////////////////////
+// inverse of 2x2 matrix
+// If cannot find inverse, set identity matrix
+///////////////////////////////////////////////////////////////////////////////
+Matrix2& Matrix2::invert()
+{
+  float determinant = getDeterminant();
+  if (fabs(determinant) <= EPSILON) {
+    return identity();
+  }
+
+  float tmp = m[0];  // copy the first element
+  float invDeterminant = 1.0f / determinant;
+  m[0] = invDeterminant * m[3];
+  m[1] = -invDeterminant * m[1];
+  m[2] = -invDeterminant * m[2];
+  m[3] = invDeterminant * tmp;
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// transpose 3x3 matrix
+///////////////////////////////////////////////////////////////////////////////
+Matrix3& Matrix3::transpose()
+{
+  std::swap(m[1], m[3]);
+  std::swap(m[2], m[6]);
+  std::swap(m[5], m[7]);
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// return determinant of 3x3 matrix
+///////////////////////////////////////////////////////////////////////////////
+float Matrix3::getDeterminant()
+{
+  return m[0] * (m[4] * m[8] - m[5] * m[7]) - m[1] * (m[3] * m[8] - m[5] * m[6]) +
+         m[2] * (m[3] * m[7] - m[4] * m[6]);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// inverse 3x3 matrix
+// If cannot find inverse, set identity matrix
+///////////////////////////////////////////////////////////////////////////////
+Matrix3& Matrix3::invert()
+{
+  float determinant, invDeterminant;
+  float tmp[9];
+
+  tmp[0] = m[4] * m[8] - m[5] * m[7];
+  tmp[1] = m[2] * m[7] - m[1] * m[8];
+  tmp[2] = m[1] * m[5] - m[2] * m[4];
+  tmp[3] = m[5] * m[6] - m[3] * m[8];
+  tmp[4] = m[0] * m[8] - m[2] * m[6];
+  tmp[5] = m[2] * m[3] - m[0] * m[5];
+  tmp[6] = m[3] * m[7] - m[4] * m[6];
+  tmp[7] = m[1] * m[6] - m[0] * m[7];
+  tmp[8] = m[0] * m[4] - m[1] * m[3];
+
+  // check determinant if it is 0
+  determinant = m[0] * tmp[0] + m[1] * tmp[3] + m[2] * tmp[6];
+  if (fabs(determinant) <= EPSILON) {
+    return identity();  // cannot inverse, make it idenety matrix
+  }
+
+  // divide by the determinant
+  invDeterminant = 1.0f / determinant;
+  m[0] = invDeterminant * tmp[0];
+  m[1] = invDeterminant * tmp[1];
+  m[2] = invDeterminant * tmp[2];
+  m[3] = invDeterminant * tmp[3];
+  m[4] = invDeterminant * tmp[4];
+  m[5] = invDeterminant * tmp[5];
+  m[6] = invDeterminant * tmp[6];
+  m[7] = invDeterminant * tmp[7];
+  m[8] = invDeterminant * tmp[8];
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// transpose 4x4 matrix
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::transpose()
+{
+  std::swap(m[1], m[4]);
+  std::swap(m[2], m[8]);
+  std::swap(m[3], m[12]);
+  std::swap(m[6], m[9]);
+  std::swap(m[7], m[13]);
+  std::swap(m[11], m[14]);
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// inverse 4x4 matrix
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::invert()
+{
+  // If the 4th row is [0,0,0,1] then it is affine matrix and
+  // it has no projective transformation.
+  if (m[3] == 0 && m[7] == 0 && m[11] == 0 && m[15] == 1)
+    this->invertAffine();
+  else {
+    this->invertGeneral();
+    /*@@ invertProjective() is not optimized (slower than generic one)
+    if(fabs(m[0]*m[5] - m[1]*m[4]) > EPSILON)
+        this->invertProjective();   // inverse using matrix partition
+    else
+        this->invertGeneral();      // generalized inverse
+    */
+  }
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// compute the inverse of 4x4 Euclidean transformation matrix
+//
+// Euclidean transformation is translation, rotation, and reflection.
+// With Euclidean transform, only the position and orientation of the object
+// will be changed. Euclidean transform does not change the shape of an object
+// (no scaling). Length and angle are reserved.
+//
+// Use inverseAffine() if the matrix has scale and shear transformation.
+//
+// M = [ R | T ]
+//     [ --+-- ]    (R denotes 3x3 rotation/reflection matrix)
+//     [ 0 | 1 ]    (T denotes 1x3 translation matrix)
+//
+// y = M*x  ->  y = R*x + T  ->  x = R^-1*(y - T)  ->  x = R^T*y - R^T*T
+// (R is orthogonal,  R^-1 = R^T)
+//
+//  [ R | T ]-1    [ R^T | -R^T * T ]    (R denotes 3x3 rotation matrix)
+//  [ --+-- ]   =  [ ----+--------- ]    (T denotes 1x3 translation)
+//  [ 0 | 1 ]      [  0  |     1    ]    (R^T denotes R-transpose)
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::invertEuclidean()
+{
+  // transpose 3x3 rotation matrix part
+  // | R^T | 0 |
+  // | ----+-- |
+  // |  0  | 1 |
+  float tmp;
+  tmp = m[1];
+  m[1] = m[4];
+  m[4] = tmp;
+  tmp = m[2];
+  m[2] = m[8];
+  m[8] = tmp;
+  tmp = m[6];
+  m[6] = m[9];
+  m[9] = tmp;
+
+  // compute translation part -R^T * T
+  // | 0 | -R^T x |
+  // | --+------- |
+  // | 0 |   0    |
+  float x = m[12];
+  float y = m[13];
+  float z = m[14];
+  m[12] = -(m[0] * x + m[4] * y + m[8] * z);
+  m[13] = -(m[1] * x + m[5] * y + m[9] * z);
+  m[14] = -(m[2] * x + m[6] * y + m[10] * z);
+
+  // last row should be unchanged (0,0,0,1)
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// compute the inverse of a 4x4 affine transformation matrix
+//
+// Affine transformations are generalizations of Euclidean transformations.
+// Affine transformation includes translation, rotation, reflection, scaling,
+// and shearing. Length and angle are NOT preserved.
+// M = [ R | T ]
+//     [ --+-- ]    (R denotes 3x3 rotation/scale/shear matrix)
+//     [ 0 | 1 ]    (T denotes 1x3 translation matrix)
+//
+// y = M*x  ->  y = R*x + T  ->  x = R^-1*(y - T)  ->  x = R^-1*y - R^-1*T
+//
+//  [ R | T ]-1   [ R^-1 | -R^-1 * T ]
+//  [ --+-- ]   = [ -----+---------- ]
+//  [ 0 | 1 ]     [  0   +     1     ]
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::invertAffine()
+{
+  // R^-1
+  Matrix3 r(m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]);
+  r.invert();
+  m[0] = r[0];
+  m[1] = r[1];
+  m[2] = r[2];
+  m[4] = r[3];
+  m[5] = r[4];
+  m[6] = r[5];
+  m[8] = r[6];
+  m[9] = r[7];
+  m[10] = r[8];
+
+  // -R^-1 * T
+  float x = m[12];
+  float y = m[13];
+  float z = m[14];
+  m[12] = -(r[0] * x + r[3] * y + r[6] * z);
+  m[13] = -(r[1] * x + r[4] * y + r[7] * z);
+  m[14] = -(r[2] * x + r[5] * y + r[8] * z);
+
+  // last row should be unchanged (0,0,0,1)
+  // m[3] = m[7] = m[11] = 0.0f;
+  // m[15] = 1.0f;
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// inverse matrix using matrix partitioning (blockwise inverse)
+// It devides a 4x4 matrix into 4 of 2x2 matrices. It works in case of where
+// det(A) != 0. If not, use the generic inverse method
+// inverse formula.
+// M = [ A | B ]    A, B, C, D are 2x2 matrix blocks
+//     [ --+-- ]    det(M) = |A| * |D - ((C * A^-1) * B)|
+//     [ C | D ]
+//
+// M^-1 = [ A' | B' ]   A' = A^-1 - (A^-1 * B) * C'
+//        [ ---+--- ]   B' = (A^-1 * B) * -D'
+//        [ C' | D' ]   C' = -D' * (C * A^-1)
+//                      D' = (D - ((C * A^-1) * B))^-1
+//
+// NOTE: I wrap with () if it it used more than once.
+//       The matrix is invertable even if det(A)=0, so must check det(A) before
+//       calling this function, and use invertGeneric() instead.
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::invertProjective()
+{
+  // partition
+  Matrix2 a(m[0], m[1], m[4], m[5]);
+  Matrix2 b(m[8], m[9], m[12], m[13]);
+  Matrix2 c(m[2], m[3], m[6], m[7]);
+  Matrix2 d(m[10], m[11], m[14], m[15]);
+
+  // pre-compute repeated parts
+  a.invert();              // A^-1
+  Matrix2 ab = a * b;      // A^-1 * B
+  Matrix2 ca = c * a;      // C * A^-1
+  Matrix2 cab = ca * b;    // C * A^-1 * B
+  Matrix2 dcab = d - cab;  // D - C * A^-1 * B
+
+  // check determinant if |D - C * A^-1 * B| = 0
+  // NOTE: this function assumes det(A) is already checked. if |A|=0 then,
+  //      cannot use this function.
+  float determinant = dcab[0] * dcab[3] - dcab[1] * dcab[2];
+  if (fabs(determinant) <= EPSILON) {
+    return identity();
+  }
+
+  // compute D' and -D'
+  Matrix2 d1 = dcab;  //  (D - C * A^-1 * B)
+  d1.invert();        //  (D - C * A^-1 * B)^-1
+  Matrix2 d2 = -d1;   // -(D - C * A^-1 * B)^-1
+
+  // compute C'
+  Matrix2 c1 = d2 * ca;  // -D' * (C * A^-1)
+
+  // compute B'
+  Matrix2 b1 = ab * d2;  // (A^-1 * B) * -D'
+
+  // compute A'
+  Matrix2 a1 = a - (ab * c1);  // A^-1 - (A^-1 * B) * C'
+
+  // assemble inverse matrix
+  m[0] = a1[0];
+  m[4] = a1[2]; /*|*/
+  m[8] = b1[0];
+  m[12] = b1[2];
+  m[1] = a1[1];
+  m[5] = a1[3]; /*|*/
+  m[9] = b1[1];
+  m[13] = b1[3];
+  /*-----------------------------+-----------------------------*/
+  m[2] = c1[0];
+  m[6] = c1[2]; /*|*/
+  m[10] = d1[0];
+  m[14] = d1[2];
+  m[3] = c1[1];
+  m[7] = c1[3]; /*|*/
+  m[11] = d1[1];
+  m[15] = d1[3];
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// compute the inverse of a general 4x4 matrix using Cramer's Rule
+// If cannot find inverse, return indentity matrix
+// M^-1 = adj(M) / det(M)
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::invertGeneral()
+{
+  // get cofactors of minor matrices
+  float cofactor0 = getCofactor(m[5], m[6], m[7], m[9], m[10], m[11], m[13], m[14], m[15]);
+  float cofactor1 = getCofactor(m[4], m[6], m[7], m[8], m[10], m[11], m[12], m[14], m[15]);
+  float cofactor2 = getCofactor(m[4], m[5], m[7], m[8], m[9], m[11], m[12], m[13], m[15]);
+  float cofactor3 = getCofactor(m[4], m[5], m[6], m[8], m[9], m[10], m[12], m[13], m[14]);
+
+  // get determinant
+  float determinant = m[0] * cofactor0 - m[1] * cofactor1 + m[2] * cofactor2 - m[3] * cofactor3;
+  if (fabs(determinant) <= EPSILON) {
+    return identity();
+  }
+
+  // get rest of cofactors for adj(M)
+  float cofactor4 = getCofactor(m[1], m[2], m[3], m[9], m[10], m[11], m[13], m[14], m[15]);
+  float cofactor5 = getCofactor(m[0], m[2], m[3], m[8], m[10], m[11], m[12], m[14], m[15]);
+  float cofactor6 = getCofactor(m[0], m[1], m[3], m[8], m[9], m[11], m[12], m[13], m[15]);
+  float cofactor7 = getCofactor(m[0], m[1], m[2], m[8], m[9], m[10], m[12], m[13], m[14]);
+
+  float cofactor8 = getCofactor(m[1], m[2], m[3], m[5], m[6], m[7], m[13], m[14], m[15]);
+  float cofactor9 = getCofactor(m[0], m[2], m[3], m[4], m[6], m[7], m[12], m[14], m[15]);
+  float cofactor10 = getCofactor(m[0], m[1], m[3], m[4], m[5], m[7], m[12], m[13], m[15]);
+  float cofactor11 = getCofactor(m[0], m[1], m[2], m[4], m[5], m[6], m[12], m[13], m[14]);
+
+  float cofactor12 = getCofactor(m[1], m[2], m[3], m[5], m[6], m[7], m[9], m[10], m[11]);
+  float cofactor13 = getCofactor(m[0], m[2], m[3], m[4], m[6], m[7], m[8], m[10], m[11]);
+  float cofactor14 = getCofactor(m[0], m[1], m[3], m[4], m[5], m[7], m[8], m[9], m[11]);
+  float cofactor15 = getCofactor(m[0], m[1], m[2], m[4], m[5], m[6], m[8], m[9], m[10]);
+
+  // build inverse matrix = adj(M) / det(M)
+  // adjugate of M is the transpose of the cofactor matrix of M
+  float invDeterminant = 1.0f / determinant;
+  m[0] = invDeterminant * cofactor0;
+  m[1] = -invDeterminant * cofactor4;
+  m[2] = invDeterminant * cofactor8;
+  m[3] = -invDeterminant * cofactor12;
+
+  m[4] = -invDeterminant * cofactor1;
+  m[5] = invDeterminant * cofactor5;
+  m[6] = -invDeterminant * cofactor9;
+  m[7] = invDeterminant * cofactor13;
+
+  m[8] = invDeterminant * cofactor2;
+  m[9] = -invDeterminant * cofactor6;
+  m[10] = invDeterminant * cofactor10;
+  m[11] = -invDeterminant * cofactor14;
+
+  m[12] = -invDeterminant * cofactor3;
+  m[13] = invDeterminant * cofactor7;
+  m[14] = -invDeterminant * cofactor11;
+  m[15] = invDeterminant * cofactor15;
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// return determinant of 4x4 matrix
+///////////////////////////////////////////////////////////////////////////////
+float Matrix4::getDeterminant()
+{
+  return m[0] * getCofactor(m[5], m[6], m[7], m[9], m[10], m[11], m[13], m[14], m[15]) -
+         m[1] * getCofactor(m[4], m[6], m[7], m[8], m[10], m[11], m[12], m[14], m[15]) +
+         m[2] * getCofactor(m[4], m[5], m[7], m[8], m[9], m[11], m[12], m[13], m[15]) -
+         m[3] * getCofactor(m[4], m[5], m[6], m[8], m[9], m[10], m[12], m[13], m[14]);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// compute cofactor of 3x3 minor matrix without sign
+// input params are 9 elements of the minor matrix
+// NOTE: The caller must know its sign.
+///////////////////////////////////////////////////////////////////////////////
+float Matrix4::getCofactor(float m0, float m1, float m2, float m3, float m4, float m5, float m6, float m7,
+                           float m8)
+{
+  return m0 * (m4 * m8 - m5 * m7) - m1 * (m3 * m8 - m5 * m6) + m2 * (m3 * m7 - m4 * m6);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// translate this matrix by (x, y, z)
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::translate(const Vector3& v) { return translate(v.x, v.y, v.z); }
+
+Matrix4& Matrix4::translate(float x, float y, float z)
+{
+  m[0] += m[3] * x;
+  m[4] += m[7] * x;
+  m[8] += m[11] * x;
+  m[12] += m[15] * x;
+  m[1] += m[3] * y;
+  m[5] += m[7] * y;
+  m[9] += m[11] * y;
+  m[13] += m[15] * y;
+  m[2] += m[3] * z;
+  m[6] += m[7] * z;
+  m[10] += m[11] * z;
+  m[14] += m[15] * z;
+
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// uniform scale
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::scale(float s) { return scale(s, s, s); }
+
+Matrix4& Matrix4::scale(float x, float y, float z)
+{
+  m[0] *= x;
+  m[4] *= x;
+  m[8] *= x;
+  m[12] *= x;
+  m[1] *= y;
+  m[5] *= y;
+  m[9] *= y;
+  m[13] *= y;
+  m[2] *= z;
+  m[6] *= z;
+  m[10] *= z;
+  m[14] *= z;
+  return *this;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// build a rotation matrix with given angle(degree) and rotation axis, then
+// multiply it with this object
+///////////////////////////////////////////////////////////////////////////////
+Matrix4& Matrix4::rotate(float angle, const Vector3& axis) { return rotate(angle, axis.x, axis.y, axis.z); }
+
+Matrix4& Matrix4::rotate(float angle, float x, float y, float z)
+{
+  float c = cosf(angle * DEG2RAD);  // cosine
+  float s = sinf(angle * DEG2RAD);  // sine
+  float c1 = 1.0f - c;              // 1 - c
+  float m0 = m[0], m4 = m[4], m8 = m[8], m12 = m[12], m1 = m[1], m5 = m[5], m9 = m[9], m13 = m[13], m2 = m[2],
+        m6 = m[6], m10 = m[10], m14 = m[14];
+
+  // build rotation matrix
+  float r0 = x * x * c1 + c;
+  float r1 = x * y * c1 + z * s;
+  float r2 = x * z * c1 - y * s;
+  float r4 = x * y * c1 - z * s;
+  float r5 = y * y * c1 + c;
+  float r6 = y * z * c1 + x * s;
+  float r8 = x * z * c1 + y * s;
+  float r9 = y * z * c1 - x * s;
+  float r10 = z * z * c1 + c;
+
+  // multiply rotation matrix
+  m[0] = r0 * m0 + r4 * m1 + r8 * m2;
+  m[1] = r1 * m0 + r5 * m1 + r9 * m2;
+  m[2] = r2 * m0 + r6 * m1 + r10 * m2;
+  m[4] = r0 * m4 + r4 * m5 + r8 * m6;
+  m[5] = r1 * m4 + r5 * m5 + r9 * m6;
+  m[6] = r2 * m4 + r6 * m5 + r10 * m6;
+  m[8] = r0 * m8 + r4 * m9 + r8 * m10;
+  m[9] = r1 * m8 + r5 * m9 + r9 * m10;
+  m[10] = r2 * m8 + r6 * m9 + r10 * m10;
+  m[12] = r0 * m12 + r4 * m13 + r8 * m14;
+  m[13] = r1 * m12 + r5 * m13 + r9 * m14;
+  m[14] = r2 * m12 + r6 * m13 + r10 * m14;
+
+  return *this;
+}
+
+Matrix4& Matrix4::rotateX(float angle)
+{
+  float c = cosf(angle * DEG2RAD);
+  float s = sinf(angle * DEG2RAD);
+  float m1 = m[1], m2 = m[2], m5 = m[5], m6 = m[6], m9 = m[9], m10 = m[10], m13 = m[13], m14 = m[14];
+
+  m[1] = m1 * c + m2 * -s;
+  m[2] = m1 * s + m2 * c;
+  m[5] = m5 * c + m6 * -s;
+  m[6] = m5 * s + m6 * c;
+  m[9] = m9 * c + m10 * -s;
+  m[10] = m9 * s + m10 * c;
+  m[13] = m13 * c + m14 * -s;
+  m[14] = m13 * s + m14 * c;
+
+  return *this;
+}
+
+Matrix4& Matrix4::rotateY(float angle)
+{
+  float c = cosf(angle * DEG2RAD);
+  float s = sinf(angle * DEG2RAD);
+  float m0 = m[0], m2 = m[2], m4 = m[4], m6 = m[6], m8 = m[8], m10 = m[10], m12 = m[12], m14 = m[14];
+
+  m[0] = m0 * c + m2 * s;
+  m[2] = m0 * -s + m2 * c;
+  m[4] = m4 * c + m6 * s;
+  m[6] = m4 * -s + m6 * c;
+  m[8] = m8 * c + m10 * s;
+  m[10] = m8 * -s + m10 * c;
+  m[12] = m12 * c + m14 * s;
+  m[14] = m12 * -s + m14 * c;
+
+  return *this;
+}
+
+Matrix4& Matrix4::rotateZ(float angle)
+{
+  float c = cosf(angle * DEG2RAD);
+  float s = sinf(angle * DEG2RAD);
+  float m0 = m[0], m1 = m[1], m4 = m[4], m5 = m[5], m8 = m[8], m9 = m[9], m12 = m[12], m13 = m[13];
+
+  m[0] = m0 * c + m1 * -s;
+  m[1] = m0 * s + m1 * c;
+  m[4] = m4 * c + m5 * -s;
+  m[5] = m4 * s + m5 * c;
+  m[8] = m8 * c + m9 * -s;
+  m[9] = m8 * s + m9 * c;
+  m[12] = m12 * c + m13 * -s;
+  m[13] = m12 * s + m13 * c;
+
+  return *this;
+}

--- a/libz11/meson.build
+++ b/libz11/meson.build
@@ -1,9 +1,11 @@
 deps_libz11 = [
   wayland_server_dep,
+  dependency('glew'),
 ]
 
 srcs_libz11 = files([
   'compositor.cc',
+  'matrices.cc',
   'render_block.cc',
   'w_compositor.cc',
   'w_compositor.h',

--- a/libz11/render_block.cc
+++ b/libz11/render_block.cc
@@ -1,4 +1,6 @@
+#include <GL/glew.h>
 #include <libz11.h>
+#include <wayland-server.h>
 
 #include "z11-server-protocol.h"
 #include "z11-server-protocol.hh"
@@ -14,11 +16,13 @@ RenderBlock* RenderBlock::Create(struct wl_client* client, uint32_t id, Composit
 }
 
 RenderBlock::RenderBlock(struct wl_client* client, uint32_t id, Compositor* compositor)
-    : sample_attr("Hello from Render Block"), created_(false)
+    : created_(false),
+      raw_buffer_resource_(nullptr),
+      link_(nullptr),
+      vertex_array_object_(0),
+      vertex_buffer_(0)
 {
   struct wl_resource* resource;
-
-  compositor->InsertRenderBlock(&this->link_);
 
   resource = wl_resource_create(client, &z11_render_block_interface, 1, id);
   if (resource == nullptr) goto no_mem_resource;
@@ -26,7 +30,11 @@ RenderBlock::RenderBlock(struct wl_client* client, uint32_t id, Compositor* comp
   z_cpp::z_render_block_resource_bind(resource, this);
 
   created_ = true;
-  raw_buffer_resource_ = nullptr;
+  link_ = new List<RenderBlock>(this);
+  compositor->PushRenderBlock(this->link_);
+
+  glGenVertexArrays(1, &vertex_array_object_);
+
   return;
 
 no_mem_resource:
@@ -34,6 +42,51 @@ no_mem_resource:
   return;
 }
 
-RenderBlock::~RenderBlock() { wl_list_remove(&this->link_); }
+RenderBlock::~RenderBlock()
+{
+  if (link_ != nullptr) {
+    link_->Remove();
+    delete link_;
+  }
+  glDeleteBuffers(1, &vertex_buffer_);
+  glDeleteVertexArrays(1, &vertex_array_object_);
+}
+
+int32_t RenderBlock::GetDataSize()
+{
+  if (raw_buffer_resource_ == nullptr) return 0;
+  struct wl_shm_raw_buffer* shm_raw_buffer = wl_shm_raw_buffer_get(raw_buffer_resource_);
+  return wl_shm_raw_buffer_get_size(shm_raw_buffer);
+}
+
+void* RenderBlock::GetData()
+{
+  if (raw_buffer_resource_ == nullptr) return nullptr;
+  struct wl_shm_raw_buffer* shm_raw_buffer = wl_shm_raw_buffer_get(raw_buffer_resource_);
+  return wl_shm_raw_buffer_get_data(shm_raw_buffer);
+}
+
+void RenderBlock::Rebind()
+{
+  glBindVertexArray(vertex_array_object_);
+  glDeleteBuffers(1, &vertex_buffer_);
+  if (raw_buffer_resource_ == nullptr) goto clean;
+  glGenBuffers(1, &vertex_buffer_);
+  glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);
+  glBufferData(GL_ARRAY_BUFFER, GetDataSize(), GetData(), GL_STATIC_DRAW);
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 0, 0);
+
+clean:
+  glBindVertexArray(0);
+  glDisableVertexAttribArray(0);
+}
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+inline void RenderBlock::Attach(struct wl_client* client, struct wl_resource* raw_buffer_resource)
+{
+  raw_buffer_resource_ = raw_buffer_resource;
+  Rebind();
+}
 
 }  // namespace z11

--- a/libz11/w_compositor.h
+++ b/libz11/w_compositor.h
@@ -17,6 +17,7 @@ class WCompositor
  private:
   bool created_;
 
+ private:
   WCompositor(struct wl_display *display);
 };
 

--- a/libz11/z_compositor.cc
+++ b/libz11/z_compositor.cc
@@ -18,7 +18,7 @@ ZCompositor* ZCompositor::Create(Compositor* compositor)
 ZCompositor::ZCompositor(Compositor* compositor) : created_(false), compositor_(compositor)
 {
   struct wl_global* global;
-  global = wl_cpp::global_create(compositor->GetDisplay(), &z11_compositor_interface, 1, this);
+  global = wl_cpp::global_create(compositor->display(), &z11_compositor_interface, 1, this);
   if (global == nullptr) return;
 
   created_ = true;
@@ -39,11 +39,9 @@ no_mem_resource:
   wl_client_post_no_memory(client);
 }
 
-Compositor* ZCompositor::GetCompositor() { return compositor_; }
-
 void ZCompositor::CreateRenderBlock(struct wl_client* client, uint32_t id)
 {
-  RenderBlock::Create(client, id, this->GetCompositor());
+  RenderBlock::Create(client, id, this->compositor());
 }
 
 }  // namespace z11

--- a/libz11/z_compositor.h
+++ b/libz11/z_compositor.h
@@ -1,5 +1,5 @@
-#ifndef Z11_Z_COMPOSITOR_H
-#define Z11_Z_COMPOSITOR_H
+#ifndef LIBZ11_Z_COMPOSITOR_H
+#define LIBZ11_Z_COMPOSITOR_H
 
 #include <libz11.h>
 #include <wayland-server.h>
@@ -11,17 +11,20 @@ class ZCompositor
  public:
   static ZCompositor *Create(Compositor *compositor);
 
-  Compositor *GetCompositor();
   void Bind(struct wl_client *client, uint32_t version, uint32_t id);
   void CreateRenderBlock(struct wl_client *client, uint32_t id);
+  Compositor *compositor();
 
  private:
   bool created_;
   Compositor *compositor_;
 
+ private:
   ZCompositor(Compositor *compositor);
 };
 
+inline Compositor *ZCompositor::compositor() { return compositor_; }
+
 }  // namespace z11
 
-#endif  // Z11_Z_COMPOSITOR_H
+#endif  // LIBZ11_Z_COMPOSITOR_H


### PR DESCRIPTION
この変更を利用するには
https://github.com/gray-armor/wayland/pull/2
この機能を使う必要があるので、CONTRIBUTINGに従ってwaylandをビルド・インストールする必要があります。

クライアントが作った線の情報をshared memory経由でrender blockに渡し、openGLとSDLを用いて画面上に描画できるようにしました。
z11-simple-boxというクライアントアプリは引数にx, y ,zをとり、その点を中心に立方体を描画します。
複数のクライアントを起動することで複数の立方体を同時に画面に描画することができます。

試してみてちょ。