### PR TITLE
Enable to render to Head Mount Display

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,41 +8,41 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: Install dependencies
-      run: |
-        sudo apt-get update &&
-        sudo apt-get install libglew-dev libsdl2-dev
-    - uses: actions/checkout@v2
-      with:
-        path: main
-    - uses: actions/checkout@v2
-      with:
-        repository: gray-armor/wayland
-        path: wayland
-    - uses: actions/setup-python@v1
-      with:
-        python-version: '3.x'
-    - run: pip install meson ninja
+      - name: Install dependencies
+        run: |
+          sudo apt-get update &&
+          sudo apt-get install libglew-dev libsdl2-dev libopenvr-dev
+      - uses: actions/checkout@v2
+        with:
+          path: main
+      - uses: actions/checkout@v2
+        with:
+          repository: gray-armor/wayland
+          path: wayland
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.x"
+      - run: pip install meson ninja
 
-    - run: meson -Ddocumentation=false -Dtests=false -Ddtd_validation=false -Dicon_directory=false --prefix=$(pwd)/target build
-      working-directory: ./wayland
-      env:
-        CC: gcc
-    - run: ninja -C build install
-      working-directory: ./wayland
-    - run: |
-        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/wayland/target/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
+      - run: meson -Ddocumentation=false -Dtests=false -Ddtd_validation=false -Dicon_directory=false --prefix=$(pwd)/target build
+        working-directory: ./wayland
+        env:
+          CC: gcc
+      - run: ninja -C build install
+        working-directory: ./wayland
+      - run: |
+          echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/wayland/target/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
 
-    - run: |
-        meson build
-      working-directory: ./main
-      env:
-        CC: gcc
-    - run: ninja -C build test
-      working-directory: ./main
+      - run: |
+          meson build
+        working-directory: ./main
+        env:
+          CC: gcc
+      - run: ninja -C build test
+        working-directory: ./main
 
-    - uses: actions/upload-artifact@v1
-      if: failure()
-      with:
-        name: Test_Log
-        path: main/build/meson-logs/testlog.txt
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: Test_Log
+          path: main/build/meson-logs/testlog.txt

--- a/compositor/eye.cc
+++ b/compositor/eye.cc
@@ -26,15 +26,15 @@ bool Eye::CreateFramebuffer()
   glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, 4, GL_RGBA8, width_, height_, true);
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, texture_id_, 0);
 
-  glGenFramebuffers(1, &copy_framebuffer_id_);
-  glBindFramebuffer(GL_FRAMEBUFFER, copy_framebuffer_id_);
+  glGenFramebuffers(1, &resolve_framebuffer_id_);
+  glBindFramebuffer(GL_FRAMEBUFFER, resolve_framebuffer_id_);
 
-  glGenTextures(1, &copy_texture_id_);
-  glBindTexture(GL_TEXTURE_2D, copy_texture_id_);
+  glGenTextures(1, &resolve_texture_id_);
+  glBindTexture(GL_TEXTURE_2D, resolve_texture_id_);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width_, height_, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, copy_texture_id_, 0);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, resolve_texture_id_, 0);
 
   GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
   if (status != GL_FRAMEBUFFER_COMPLETE) return false;

--- a/compositor/eye.cc
+++ b/compositor/eye.cc
@@ -25,6 +25,17 @@ bool Eye::CreateFramebuffer()
   glBindTexture(GL_TEXTURE_2D_MULTISAMPLE, texture_id_);
   glTexImage2DMultisample(GL_TEXTURE_2D_MULTISAMPLE, 4, GL_RGBA8, width_, height_, true);
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D_MULTISAMPLE, texture_id_, 0);
+
+  glGenFramebuffers(1, &copy_framebuffer_id_);
+  glBindFramebuffer(GL_FRAMEBUFFER, copy_framebuffer_id_);
+
+  glGenTextures(1, &copy_texture_id_);
+  glBindTexture(GL_TEXTURE_2D, copy_texture_id_);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, width_, height_, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, copy_texture_id_, 0);
+
   GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
   if (status != GL_FRAMEBUFFER_COMPLETE) return false;
 

--- a/compositor/eye.h
+++ b/compositor/eye.h
@@ -11,8 +11,8 @@ class Eye
   void set_view_projection(Matrix4 view_projection);
   Matrix4 view_projection();
   GLuint framebuffer_id();
-  GLuint copy_framebuffer_id();
-  GLuint copy_texture_id();
+  GLuint resolve_framebuffer_id();
+  GLuint resolve_texture_id();
   uint32_t width();
   uint32_t height();
 
@@ -21,9 +21,9 @@ class Eye
   uint32_t height_;
   Matrix4 view_projection_;
   GLuint framebuffer_id_;
-  GLuint copy_framebuffer_id_;
+  GLuint resolve_framebuffer_id_;
   GLuint texture_id_;
-  GLuint copy_texture_id_;
+  GLuint resolve_texture_id_;  // TODO: Remove if unnecessary
   GLuint depthbuffer_id_;
 
  private:
@@ -35,9 +35,9 @@ inline void Eye::set_view_projection(Matrix4 view_projection) { view_projection_
 inline Matrix4 Eye::view_projection() { return view_projection_; }
 
 inline GLuint Eye::framebuffer_id() { return framebuffer_id_; }
-inline GLuint Eye::copy_framebuffer_id() { return copy_framebuffer_id_; }
+inline GLuint Eye::resolve_framebuffer_id() { return resolve_framebuffer_id_; }
 
-inline GLuint Eye::copy_texture_id() { return copy_texture_id_; }
+inline GLuint Eye::resolve_texture_id() { return resolve_texture_id_; }
 
 inline uint32_t Eye::width() { return width_; }
 inline uint32_t Eye::height() { return height_; }

--- a/compositor/eye.h
+++ b/compositor/eye.h
@@ -8,8 +8,8 @@ class Eye
 {
  public:
   bool Init(uint32_t renderWidth, uint32_t renderHeight);
-  void set_projection(Matrix4 projection);
-  Matrix4 projection();
+  void set_view_projection(Matrix4 view_projection);
+  Matrix4 view_projection();
   GLuint framebuffer_id();
   GLuint copy_framebuffer_id();
   GLuint copy_texture_id();
@@ -19,7 +19,7 @@ class Eye
  private:
   uint32_t width_;
   uint32_t height_;
-  Matrix4 projection_;
+  Matrix4 view_projection_;
   GLuint framebuffer_id_;
   GLuint copy_framebuffer_id_;
   GLuint texture_id_;
@@ -30,9 +30,9 @@ class Eye
   bool CreateFramebuffer();
 };
 
-inline void Eye::set_projection(Matrix4 projection) { projection_ = projection; }
+inline void Eye::set_view_projection(Matrix4 view_projection) { view_projection_ = view_projection; }
 
-inline Matrix4 Eye::projection() { return projection_; }
+inline Matrix4 Eye::view_projection() { return view_projection_; }
 
 inline GLuint Eye::framebuffer_id() { return framebuffer_id_; }
 inline GLuint Eye::copy_framebuffer_id() { return copy_framebuffer_id_; }

--- a/compositor/eye.h
+++ b/compositor/eye.h
@@ -11,6 +11,8 @@ class Eye
   void set_projection(Matrix4 projection);
   Matrix4 projection();
   GLuint framebuffer_id();
+  GLuint copy_framebuffer_id();
+  GLuint copy_texture_id();
   uint32_t width();
   uint32_t height();
 
@@ -19,7 +21,9 @@ class Eye
   uint32_t height_;
   Matrix4 projection_;
   GLuint framebuffer_id_;
+  GLuint copy_framebuffer_id_;
   GLuint texture_id_;
+  GLuint copy_texture_id_;
   GLuint depthbuffer_id_;
 
  private:
@@ -31,6 +35,9 @@ inline void Eye::set_projection(Matrix4 projection) { projection_ = projection; 
 inline Matrix4 Eye::projection() { return projection_; }
 
 inline GLuint Eye::framebuffer_id() { return framebuffer_id_; }
+inline GLuint Eye::copy_framebuffer_id() { return copy_framebuffer_id_; }
+
+inline GLuint Eye::copy_texture_id() { return copy_texture_id_; }
 
 inline uint32_t Eye::width() { return width_; }
 inline uint32_t Eye::height() { return height_; }

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -30,17 +30,12 @@ bool HMD::Init()
   return true;
 }
 
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-bool HMD::InitGL() { return true; }
-
 void HMD::Shutdown()
 {
   if (vr_system_) {
     vr::VR_Shutdown();
     vr_system_ = NULL;
   }
-
-  // TODO: Delete Framebuffers, Textures, Vertex Arrays
 }
 
 void HMD::Submit(Eye *left_eye, Eye *right_eye)
@@ -102,8 +97,8 @@ Matrix4 HMD::ProjectionMatrix(vr::Hmd_Eye hmd_eye)
 {
   if (!vr_system_) return Matrix4();
 
-  float nearClip = 0.1;
-  float farClip = 200.0;
+  float nearClip = 0.1f;
+  float farClip = 200.0f;
 
   vr::HmdMatrix44_t mat = vr_system_->GetProjectionMatrix(hmd_eye, nearClip, farClip);
 

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -22,10 +22,8 @@ bool HMD::Init()
   fprintf(stdout, "HMD display width : %d\n", display_width_);
   fprintf(stdout, "HMD display height: %d\n", display_height_);
 
-  projection_left_ = ProjectionMatrix(vr::Eye_Left);
-  projection_right_ = ProjectionMatrix(vr::Eye_Right);
-  head_to_view_left_ = HeadToViewMatrix(vr::Eye_Left);
-  head_to_view_right_ = HeadToViewMatrix(vr::Eye_Right);
+  head_to_view_projection_left_ = ProjectionMatrix(vr::Eye_Left) * HeadToViewMatrix(vr::Eye_Left);
+  head_to_view_projection_right_ = ProjectionMatrix(vr::Eye_Right) * HeadToViewMatrix(vr::Eye_Right);
   right_handed_to_left_coord_system_ = ConvertRightToLeftHandedCoordSystemMatrix();
 
   return true;
@@ -74,10 +72,9 @@ Matrix4 HMD::ViewProjectionMatrix(HmdEye hmd_eye)
 {
   Matrix4 viewProjection;
   if (hmd_eye == kLeftEye) {
-    viewProjection = projection_left_ * head_to_view_left_ * head_pose_ * right_handed_to_left_coord_system_;
+    viewProjection = head_to_view_projection_left_ * head_pose_ * right_handed_to_left_coord_system_;
   } else {
-    viewProjection =
-        projection_right_ * head_to_view_right_ * head_pose_ * right_handed_to_left_coord_system_;
+    viewProjection = head_to_view_projection_right_ * head_pose_ * right_handed_to_left_coord_system_;
   }
   return viewProjection;
 }

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -41,16 +41,16 @@ void HMD::Shutdown()
 void HMD::Submit(Eye *left_eye, Eye *right_eye)
 {
   vr::Texture_t leftEyeTexture = {
-      (void *)(uintptr_t)left_eye->copy_texture_id(),  //
-      vr::TextureType_OpenGL,                          //
-      vr::ColorSpace_Gamma                             //
+      (void *)(uintptr_t)left_eye->resolve_texture_id(),  //
+      vr::TextureType_OpenGL,                             //
+      vr::ColorSpace_Gamma                                //
   };
   vr::VRCompositor()->Submit(vr::Eye_Left, &leftEyeTexture);
 
   vr::Texture_t rightEyeTexture = {
-      (void *)(uintptr_t)right_eye->copy_texture_id(),  //
-      vr::TextureType_OpenGL,                           //
-      vr::ColorSpace_Gamma                              //
+      (void *)(uintptr_t)right_eye->resolve_texture_id(),  //
+      vr::TextureType_OpenGL,                              //
+      vr::ColorSpace_Gamma                                 //
   };
   vr::VRCompositor()->Submit(vr::Eye_Right, &rightEyeTexture);
 }

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -24,8 +24,8 @@ bool HMD::Init()
 
   projection_left_ = ProjectionMatrix(vr::Eye_Left);
   projection_right_ = ProjectionMatrix(vr::Eye_Right);
-  head_to_eye_left_ = HeadToEyeMatrix(vr::Eye_Left);
-  head_to_eye_right_ = HeadToEyeMatrix(vr::Eye_Right);
+  head_to_view_left_ = HeadToViewMatrix(vr::Eye_Left);
+  head_to_view_right_ = HeadToViewMatrix(vr::Eye_Right);
 
   return true;
 }
@@ -75,10 +75,10 @@ Matrix4 HMD::ViewProjectionMatrix(vr::Hmd_Eye hmd_eye)
   Matrix4 viewProjection;
   Matrix4 view;
   if (hmd_eye == vr::Eye_Left) {
-    view = head_to_eye_left_ * head_pose_;
+    view = head_to_view_left_ * head_pose_;
     viewProjection = projection_left_ * view;
   } else {
-    view = head_to_eye_right_ * head_pose_;
+    view = head_to_view_right_ * head_pose_;
     viewProjection = projection_right_ * view;
   }
   return viewProjection;
@@ -109,11 +109,12 @@ Matrix4 HMD::ProjectionMatrix(vr::Hmd_Eye hmd_eye)
   );
 }
 
-Matrix4 HMD::HeadToEyeMatrix(vr::Hmd_Eye hmd_eye)
+Matrix4 HMD::HeadToViewMatrix(vr::Hmd_Eye hmd_eye)
 {
   if (!vr_system_) return Matrix4();
 
   vr::HmdMatrix34_t mat = vr_system_->GetEyeToHeadTransform(hmd_eye);
+
   Matrix4 eyeToHead(mat.m[0][0], mat.m[1][0], mat.m[2][0], 0.0,  //
                     mat.m[0][1], mat.m[1][1], mat.m[2][1], 0.0,  //
                     mat.m[0][2], mat.m[1][2], mat.m[2][2], 0.0,  //

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -125,10 +125,10 @@ Matrix4 HMD::HeadToViewMatrix(vr::Hmd_Eye hmd_eye)
 // TODO: Use OpenGL API if exists;
 Matrix4 HMD::ConvertRightToLeftHandedCoordSystemMatrix()
 {
-  return Matrix4(           //
-      1.0, 0.0, 0.0, 0.0,   //
-      0.0, 1.0, 0.0, 0.0,   //
-      0.0, 0.0, -1.0, 0.0,  //
-      0.0, 0.0, 0.0, 1.0f   //
+  return Matrix4(   //
+      1, 0, 0, 0,   //
+      0, 1, 0, 0,   //
+      0, 0, -1, 0,  //
+      0, 0, 0, 1    //
   );
 }

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -26,34 +26,8 @@ bool HMD::Init()
 }
 
 #pragma GCC diagnostic ignored "-Wunused-parameter"
-bool HMD::InitGL(Eye *left_eye, Eye *right_eye)
+bool HMD::InitGL()
 {
-  // create framebuffer for left eye copy
-  glGenFramebuffers(1, &left_copy_framebuffer_id_);
-  glBindFramebuffer(GL_FRAMEBUFFER, left_copy_framebuffer_id_);
-
-  glGenTextures(1, &left_copy_texture_id_);
-  glBindTexture(GL_TEXTURE_2D, left_copy_texture_id_);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, left_eye->width(), left_eye->height(), 0, GL_RGBA,
-               GL_UNSIGNED_BYTE, nullptr);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, left_copy_texture_id_, 0);
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-  // create framebuffer for right eye copy
-  glGenFramebuffers(1, &right_copy_framebuffer_id_);
-  glBindFramebuffer(GL_FRAMEBUFFER, right_copy_framebuffer_id_);
-
-  glGenTextures(1, &right_copy_texture_id_);
-  glBindTexture(GL_TEXTURE_2D, right_copy_texture_id_);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, left_eye->width(), left_eye->height(), 0, GL_RGBA,
-               GL_UNSIGNED_BYTE, nullptr);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, right_copy_texture_id_, 0);
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
   if (shader_.Init(  //
           "Scene",
 

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -1,0 +1,139 @@
+#include "hmd.h"
+
+#include <openvr/openvr.h>
+
+bool HMD::Init()
+{
+  vr::EVRInitError initError = vr::VRInitError_None;
+  vr_system_ = vr::VR_Init(&initError, vr::VRApplication_Scene);
+  if (initError != vr::VRInitError_None) {
+    fprintf(stdout, "Unable to init OpenVR!\n");
+    return false;
+  }
+
+  if (!vr::VRCompositor()) {
+    fprintf(stdout, "Unable to init VR Compositor!\n");
+    return false;
+  }
+
+  vr_system_->GetRecommendedRenderTargetSize(&display_width_, &display_height_);
+  fprintf(stdout, "HMD display width : %d\n", display_width_);
+  fprintf(stdout, "HMD display height: %d\n", display_height_);
+
+  return true;
+}
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+bool HMD::InitGL(Eye *left_eye, Eye *right_eye)
+{
+  // TODO: sceneとobjectの描画、どのタイミングでやる？ Initで背景の設定, Drawでオブジェクト
+  if (shader_.Init(  //
+          "Scene",
+
+          // vertex shader
+          "#version 410\n"
+          "uniform mat4 model;\n"
+          "layout(location = 0) in vec4 position;\n"
+          "layout(location = 1) in vec2 v2UVcoordsIn;\n"
+          "layout(location = 2) in vec3 v3NormalIn;\n"
+          "out vec2 v2UVcoords;\n"
+          "void main()\n"
+          "{\n"
+          "	v2UVcoords = v2UVcoordsIn;\n"
+          "	gl_Position = model * position;\n"
+          "}\n",
+
+          // fragment shader
+          "#version 410 core\n"
+          "uniform sampler2D mytexture;\n"
+          "in vec2 v2UVcoords;\n"
+          "out vec4 outputColor;\n"
+          "void main()\n"
+          "{\n"
+          // "   outputColor = vec4(1.0, 0.0, 0.0, 1.0);\n"
+          "   outputColor = texture(mytexture, v2UVcoords);\n"
+          "}\n") == false)
+    return false;
+  matrix_location_ = glGetUniformLocation(shader_.id(), "model");
+  if (matrix_location_ == (GLuint)-1) {
+    fprintf(stdout, "Unable to find matrix uniform in scene shader\n");
+    return false;
+  }
+
+  glGenVertexArrays(1, &vertex_array_object_);
+  glBindVertexArray(vertex_array_object_);
+
+  // glGenBuffers(1, &vertex_buffer_);
+  // glBindBuffer(GL_ARRAY_BUFFER, vertex_buffer_);
+  // glBufferData(GL_ARRAY_BUFFER, sizeof(float) * vertdataarray.size(), &vertdataarray[0], GL_STATIC_DRAW);
+
+  glEnableVertexAttribArray(0);
+  glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(VertexDataScene),
+                        (void *)offsetof(VertexDataScene, position));
+
+  glEnableVertexAttribArray(1);
+  glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, sizeof(VertexDataScene),
+                        (void *)offsetof(VertexDataScene, texCoord));
+
+  glBindVertexArray(0);
+
+  glDisableVertexAttribArray(0);
+  glDisableVertexAttribArray(1);
+
+  return true;
+}
+
+void HMD::Draw(Eye *left_eye, Eye *right_eye)
+{
+  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+  glEnable(GL_DEPTH_TEST);
+
+  glUseProgram(shader_.id());
+  glUniformMatrix4fv(matrix_location_, 1, GL_FALSE, GetCurrentViewProjectionMatrix(left_eye).get());
+  glBindVertexArray(vertex_array_object_);
+  glBindTexture(GL_TEXTURE_2D, texture_);
+  glDrawArrays(GL_TRIANGLES, 0, vertex_count_);
+
+  glUniformMatrix4fv(matrix_location_, 1, GL_FALSE, GetCurrentViewProjectionMatrix(right_eye).get());
+  glBindVertexArray(vertex_array_object_);
+  glBindTexture(GL_TEXTURE_2D, texture_);
+  glDrawArrays(GL_TRIANGLES, 0, vertex_count_);
+  glUseProgram(0);
+}
+
+void HMD::Shutdown()
+{
+  if (vr_system_) {
+    vr::VR_Shutdown();
+    vr_system_ = NULL;
+  }
+}
+
+void HMD::UpdateHeadPose()
+{
+  if (vr_system_) return;
+
+  vr::VRCompositor()->WaitGetPoses(tracked_device_pose_list_, vr::k_unMaxTrackedDeviceCount, NULL, 0);
+
+  const uint32_t hmdIndex = vr::k_unTrackedDeviceIndex_Hmd;
+
+  if (tracked_device_pose_list_[hmdIndex].bPoseIsValid) {
+    head_pose_ = ConvertSteamVRMatrixToMatrix4(tracked_device_pose_list_[hmdIndex].mDeviceToAbsoluteTracking);
+    head_pose_.invert();
+  }
+}
+
+Matrix4 HMD::GetCurrentViewProjectionMatrix(Eye *eye)
+{
+  Matrix4 viewProjection = eye->projection() * head_pose_;
+  return viewProjection;
+}
+
+Matrix4 HMD::ConvertSteamVRMatrixToMatrix4(vr::HmdMatrix34_t &pose)
+{
+  Matrix4 mat(pose.m[0][0], pose.m[1][0], pose.m[2][0], 0.0,    //
+              pose.m[0][1], pose.m[1][1], pose.m[2][1], 0.0,    //
+              pose.m[0][2], pose.m[1][2], pose.m[2][2], 0.0,    //
+              pose.m[0][3], pose.m[1][3], pose.m[2][3], 1.0f);  //
+  return mat;
+}

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -26,7 +26,6 @@ bool HMD::Init()
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 bool HMD::InitGL(Eye *left_eye, Eye *right_eye)
 {
-  // TODO: sceneとobjectの描画、どのタイミングでやる？ Initで背景の設定, Drawでオブジェクト
   if (shader_.Init(  //
           "Scene",
 

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -40,7 +40,6 @@ void HMD::Shutdown()
 
 void HMD::Submit(Eye *left_eye, Eye *right_eye)
 {
-  // fprintf(stdout, "submit\n");
   vr::Texture_t leftEyeTexture = {
       (void *)(uintptr_t)left_eye->copy_texture_id(),  //
       vr::TextureType_OpenGL,                          //
@@ -70,16 +69,13 @@ void HMD::UpdateHeadPose()
   }
 }
 
-Matrix4 HMD::ViewProjectionMatrix(vr::Hmd_Eye hmd_eye)
+Matrix4 HMD::ViewProjectionMatrix(EyeDirection eye_direction)
 {
   Matrix4 viewProjection;
-  Matrix4 view;
-  if (hmd_eye == vr::Eye_Left) {
-    view = head_to_view_left_ * head_pose_;
-    viewProjection = projection_left_ * view;
+  if (eye_direction == kLeftEye) {
+    viewProjection = projection_left_ * head_to_view_left_ * head_pose_;
   } else {
-    view = head_to_view_right_ * head_pose_;
-    viewProjection = projection_right_ * view;
+    viewProjection = projection_right_ * head_to_view_right_ * head_pose_;
   }
   return viewProjection;
 }

--- a/compositor/hmd.cc
+++ b/compositor/hmd.cc
@@ -70,10 +70,10 @@ void HMD::UpdateHeadPose()
   }
 }
 
-Matrix4 HMD::ViewProjectionMatrix(EyeDirection eye_direction)
+Matrix4 HMD::ViewProjectionMatrix(HmdEye hmd_eye)
 {
   Matrix4 viewProjection;
-  if (eye_direction == kLeftEye) {
+  if (hmd_eye == kLeftEye) {
     viewProjection = projection_left_ * head_to_view_left_ * head_pose_ * right_handed_to_left_coord_system_;
   } else {
     viewProjection =

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -25,16 +25,16 @@ class HMD
   uint32_t display_height_;
   vr::IVRSystem *vr_system_;
   vr::TrackedDevicePose_t tracked_device_pose_list_[vr::k_unMaxTrackedDeviceCount];
-  Matrix4 head_pose_;
   Matrix4 projection_left_;
   Matrix4 projection_right_;
-  Matrix4 head_to_eye_left_;
-  Matrix4 head_to_eye_right_;
+  Matrix4 head_to_view_left_;
+  Matrix4 head_to_view_right_;
+  Matrix4 head_pose_;
 
  private:
   Matrix4 ConvertSteamVRMatrixToMatrix4(vr::HmdMatrix34_t &pose);
   Matrix4 ProjectionMatrix(vr::Hmd_Eye hmd_eye);
-  Matrix4 HeadToEyeMatrix(vr::Hmd_Eye hmd_eye);
+  Matrix4 HeadToViewMatrix(vr::Hmd_Eye hmd_eye);
 };
 
 inline uint32_t HMD::display_width() { return display_width_; }

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -16,7 +16,11 @@ class HMD
   void UpdateHeadPose();
   void Submit(Eye *left_eye, Eye *right_eye);
   void Shutdown();
-  Matrix4 ViewProjectionMatrix(vr::Hmd_Eye hmd_eye);
+  enum EyeDirection {
+    kLeftEye = vr::Eye_Left,
+    kRightEye = vr::Eye_Right,
+  };
+  Matrix4 ViewProjectionMatrix(EyeDirection eye_direction);
   uint32_t display_width();
   uint32_t display_height();
 

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -31,10 +31,8 @@ class HMD
   uint32_t display_height_;
   vr::IVRSystem *vr_system_;
   vr::TrackedDevicePose_t tracked_device_pose_list_[vr::k_unMaxTrackedDeviceCount];
-  Matrix4 projection_left_;
-  Matrix4 projection_right_;
-  Matrix4 head_to_view_left_;
-  Matrix4 head_to_view_right_;
+  Matrix4 head_to_view_projection_left_;
+  Matrix4 head_to_view_projection_right_;
   Matrix4 head_pose_;
   Matrix4 right_handed_to_left_coord_system_;
 

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -12,7 +12,7 @@ struct VertexDataScene {
 class HMD
 {
  public:
-  enum EyeDirection {
+  enum HmdEye {
     kLeftEye = vr::Eye_Left,
     kRightEye = vr::Eye_Right,
   };
@@ -22,7 +22,7 @@ class HMD
   void UpdateHeadPose();
   void Submit(Eye *left_eye, Eye *right_eye);
   void Shutdown();
-  Matrix4 ViewProjectionMatrix(EyeDirection eye_direction);
+  Matrix4 ViewProjectionMatrix(HmdEye hmd_eye);
   uint32_t display_width();
   uint32_t display_height();
 

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -12,14 +12,16 @@ struct VertexDataScene {
 class HMD
 {
  public:
-  bool Init();
-  void UpdateHeadPose();
-  void Submit(Eye *left_eye, Eye *right_eye);
-  void Shutdown();
   enum EyeDirection {
     kLeftEye = vr::Eye_Left,
     kRightEye = vr::Eye_Right,
   };
+
+ public:
+  bool Init();
+  void UpdateHeadPose();
+  void Submit(Eye *left_eye, Eye *right_eye);
+  void Shutdown();
   Matrix4 ViewProjectionMatrix(EyeDirection eye_direction);
   uint32_t display_width();
   uint32_t display_height();

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -13,7 +13,6 @@ class HMD
 {
  public:
   bool Init();
-  bool InitGL();
   void UpdateHeadPose();
   void Submit(Eye *left_eye, Eye *right_eye);
   void Shutdown();
@@ -25,12 +24,8 @@ class HMD
   uint32_t display_width_;
   uint32_t display_height_;
   vr::IVRSystem *vr_system_;
-  Shader shader_;
-  unsigned int vertex_count_;
-  GLuint vertex_array_object_;
-  GLuint vertex_buffer_;
-  Matrix4 head_pose_;
   vr::TrackedDevicePose_t tracked_device_pose_list_[vr::k_unMaxTrackedDeviceCount];
+  Matrix4 head_pose_;
   Matrix4 projection_left_;
   Matrix4 projection_right_;
   Matrix4 head_to_eye_left_;

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -14,18 +14,15 @@ class HMD
  public:
   uint32_t display_width_;
   uint32_t display_height_;
-  GLuint left_copy_texture_id_;
-  GLuint left_copy_framebuffer_id_;
-  GLuint right_copy_texture_id_;
-  GLuint right_copy_framebuffer_id_;
 
  public:
   bool Init();
   bool InitGL();
   void Draw(Eye *left_eye, Eye *right_eye);
-  void Shutdown();
   void UpdateHeadPose();
-  void Submit();
+  void Submit(Eye *left_eye, Eye *right_eye);
+  void Shutdown();
+  Matrix4 GetCurrentViewProjectionMatrix(vr::Hmd_Eye hmd_eye);
 
  private:
   vr::IVRSystem *vr_system_;
@@ -35,8 +32,13 @@ class HMD
   GLuint vertex_buffer_;
   Matrix4 head_pose_;
   vr::TrackedDevicePose_t tracked_device_pose_list_[vr::k_unMaxTrackedDeviceCount];
+  Matrix4 projection_left_;
+  Matrix4 projection_right_;
+  Matrix4 eye_pose_left_;
+  Matrix4 eye_pose_right_;
 
  private:
   Matrix4 ConvertSteamVRMatrixToMatrix4(vr::HmdMatrix34_t &pose);
-  Matrix4 GetCurrentViewProjectionMatrix(Eye *eye);
+  Matrix4 GetProjectionEye(vr::Hmd_Eye hmd_eye);
+  Matrix4 GetPoseEye(vr::Hmd_Eye hmd_eye);
 };

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -12,20 +12,25 @@ struct VertexDataScene {
 class HMD
 {
  public:
+  uint32_t display_width_;
+  uint32_t display_height_;
+  GLuint left_copy_texture_id_;
+  GLuint left_copy_framebuffer_id_;
+  GLuint right_copy_texture_id_;
+  GLuint right_copy_framebuffer_id_;
+
+ public:
   bool Init();
   bool InitGL(Eye *left_eye, Eye *right_eye);
   void Draw(Eye *left_eye, Eye *right_eye);
   void Shutdown();
   void UpdateHeadPose();
+  void Submit();
 
  private:
   vr::IVRSystem *vr_system_;
   Shader shader_;
-  uint32_t display_width_;
-  uint32_t display_height_;
   unsigned int vertex_count_;
-  GLuint texture_;
-  GLuint matrix_location_;
   GLuint vertex_array_object_;
   GLuint vertex_buffer_;
   Matrix4 head_pose_;

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -21,7 +21,7 @@ class HMD
 
  public:
   bool Init();
-  bool InitGL(Eye *left_eye, Eye *right_eye);
+  bool InitGL();
   void Draw(Eye *left_eye, Eye *right_eye);
   void Shutdown();
   void UpdateHeadPose();

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -36,11 +36,13 @@ class HMD
   Matrix4 head_to_view_left_;
   Matrix4 head_to_view_right_;
   Matrix4 head_pose_;
+  Matrix4 right_handed_to_left_coord_system_;
 
  private:
-  Matrix4 ConvertSteamVRMatrixToMatrix4(vr::HmdMatrix34_t &pose);
+  Matrix4 ConvertSteamVRMatrixToMatrix(vr::HmdMatrix34_t &pose);
   Matrix4 ProjectionMatrix(vr::Hmd_Eye hmd_eye);
   Matrix4 HeadToViewMatrix(vr::Hmd_Eye hmd_eye);
+  Matrix4 ConvertRightToLeftHandedCoordSystemMatrix();
 };
 
 inline uint32_t HMD::display_width() { return display_width_; }

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -12,19 +12,18 @@ struct VertexDataScene {
 class HMD
 {
  public:
-  uint32_t display_width_;
-  uint32_t display_height_;
-
- public:
   bool Init();
   bool InitGL();
-  void Draw(Eye *left_eye, Eye *right_eye);
   void UpdateHeadPose();
   void Submit(Eye *left_eye, Eye *right_eye);
   void Shutdown();
-  Matrix4 GetCurrentViewProjectionMatrix(vr::Hmd_Eye hmd_eye);
+  Matrix4 ViewProjectionMatrix(vr::Hmd_Eye hmd_eye);
+  uint32_t display_width();
+  uint32_t display_height();
 
  private:
+  uint32_t display_width_;
+  uint32_t display_height_;
   vr::IVRSystem *vr_system_;
   Shader shader_;
   unsigned int vertex_count_;
@@ -34,11 +33,14 @@ class HMD
   vr::TrackedDevicePose_t tracked_device_pose_list_[vr::k_unMaxTrackedDeviceCount];
   Matrix4 projection_left_;
   Matrix4 projection_right_;
-  Matrix4 eye_pose_left_;
-  Matrix4 eye_pose_right_;
+  Matrix4 head_to_eye_left_;
+  Matrix4 head_to_eye_right_;
 
  private:
   Matrix4 ConvertSteamVRMatrixToMatrix4(vr::HmdMatrix34_t &pose);
-  Matrix4 GetProjectionEye(vr::Hmd_Eye hmd_eye);
-  Matrix4 GetPoseEye(vr::Hmd_Eye hmd_eye);
+  Matrix4 ProjectionMatrix(vr::Hmd_Eye hmd_eye);
+  Matrix4 HeadToEyeMatrix(vr::Hmd_Eye hmd_eye);
 };
+
+inline uint32_t HMD::display_width() { return display_width_; }
+inline uint32_t HMD::display_height() { return display_height_; }

--- a/compositor/hmd.h
+++ b/compositor/hmd.h
@@ -1,0 +1,37 @@
+#include <openvr/openvr.h>
+#include <z11/vectors.h>
+
+#include "eye.h"
+#include "shader.h"
+
+struct VertexDataScene {
+  Vector3 position;
+  Vector2 texCoord;
+};
+
+class HMD
+{
+ public:
+  bool Init();
+  bool InitGL(Eye *left_eye, Eye *right_eye);
+  void Draw(Eye *left_eye, Eye *right_eye);
+  void Shutdown();
+  void UpdateHeadPose();
+
+ private:
+  vr::IVRSystem *vr_system_;
+  Shader shader_;
+  uint32_t display_width_;
+  uint32_t display_height_;
+  unsigned int vertex_count_;
+  GLuint texture_;
+  GLuint matrix_location_;
+  GLuint vertex_array_object_;
+  GLuint vertex_buffer_;
+  Matrix4 head_pose_;
+  vr::TrackedDevicePose_t tracked_device_pose_list_[vr::k_unMaxTrackedDeviceCount];
+
+ private:
+  Matrix4 ConvertSteamVRMatrixToMatrix4(vr::HmdMatrix34_t &pose);
+  Matrix4 GetCurrentViewProjectionMatrix(Eye *eye);
+};

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -79,7 +79,7 @@ bool Main::Init()
   uint32_t renderWidth;
   uint32_t renderHeight;
   if (with_hmd_) {
-    renderWidth = hmd_->display_width_;
+    renderWidth = hmd_->display_width_;  // TODO: メンバはメソッドを通してアクセスするようにする
     renderHeight = hmd_->display_height_;
   } else {
     renderWidth = 320;
@@ -106,12 +106,14 @@ void Main::RunMainLoop()
 
     run_ = head_->ProcessEvents();
 
-    renderer_->Render(left_eye_, compositor_->render_block_list());
-    renderer_->Render(right_eye_, compositor_->render_block_list());
+    renderer_->Render(left_eye_, compositor_->render_block_list(),
+                      hmd_->GetCurrentViewProjectionMatrix(vr::Eye_Left).get());
+    renderer_->Render(right_eye_, compositor_->render_block_list(),
+                      hmd_->GetCurrentViewProjectionMatrix(vr::Eye_Right).get());
 
     if (with_hmd_) {
-      hmd_->Draw(left_eye_, right_eye_);
-      hmd_->Submit();
+      // hmd_->Draw(left_eye_, right_eye_);
+      hmd_->Submit(left_eye_, right_eye_);
       hmd_->UpdateHeadPose();
     }
 

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -89,10 +89,10 @@ bool Main::Init()
   if (right_eye_->Init(renderWidth, renderHeight) == false) return false;
   SetEyeProjection();
 
-  if (head_->InitGL(left_eye_, right_eye_) == false) return false;
+  if (head_->InitGL() == false) return false;
 
   if (with_hmd_) {
-    if (hmd_->InitGL(left_eye_, right_eye_) == false) return false;
+    if (hmd_->InitGL() == false) return false;
   }
 
   return true;

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -2,6 +2,7 @@
 #include <libz11.h>
 
 #include "eye.h"
+#include "hmd.h"
 #include "renderer.h"
 #include "sdl.h"
 
@@ -20,6 +21,7 @@ class Main
   Renderer *renderer_;
 
   SDLHead *head_;
+  HMD *hmd_;
   bool run_;
 
  private:
@@ -39,6 +41,9 @@ bool Main::Init()
   head_ = new SDLHead();
   if (head_->Init() == false) return false;
 
+  hmd_ = new HMD();
+  if (hmd_->Init() == false) return false;
+
   GLenum glewError = glewInit();
   if (glewError != GLEW_OK) {
     fprintf(stdout, "%s - Error initializing GLEW! %s\n", __FUNCTION__, glewGetErrorString(glewError));
@@ -57,6 +62,8 @@ bool Main::Init()
 
   if (head_->InitGL(left_eye_, right_eye_) == false) return false;
 
+  if (hmd_->InitGL(left_eye_, right_eye_) == false) return false;
+
   return true;
 }
 
@@ -70,6 +77,9 @@ void Main::RunMainLoop()
 
     renderer_->Render(left_eye_, compositor_->render_block_list());
     renderer_->Render(right_eye_, compositor_->render_block_list());
+
+    hmd_->Draw(left_eye_, right_eye_);
+    hmd_->UpdateHeadPose();
 
     head_->Draw(left_eye_, right_eye_);
     head_->Swap();

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -56,8 +56,10 @@ bool Main::Init()
 
   left_eye_ = new Eye();
   right_eye_ = new Eye();
-  if (left_eye_->Init(320, 320) == false) return false;
-  if (right_eye_->Init(320, 320) == false) return false;
+  if (left_eye_->Init(hmd_->display_width_, hmd_->display_height_) == false) return false;
+  if (right_eye_->Init(hmd_->display_width_, hmd_->display_height_) == false) return false;
+  // if (left_eye_->Init(320, 320) == false) return false;
+  // if (right_eye_->Init(320, 320) == false) return false;
   SetEyeProjection();
 
   if (head_->InitGL(left_eye_, right_eye_) == false) return false;
@@ -79,6 +81,7 @@ void Main::RunMainLoop()
     renderer_->Render(right_eye_, compositor_->render_block_list());
 
     hmd_->Draw(left_eye_, right_eye_);
+    hmd_->Submit();
     hmd_->UpdateHeadPose();
 
     head_->Draw(left_eye_, right_eye_);

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -103,12 +103,12 @@ void Main::RunMainLoop()
     run_ = head_->ProcessEvents();
 
     if (with_hmd_) {
-      left_eye_->set_view_projection(hmd_->ViewProjectionMatrix(vr::Eye_Left));
-      right_eye_->set_view_projection(hmd_->ViewProjectionMatrix(vr::Eye_Left));
+      left_eye_->set_view_projection(hmd_->ViewProjectionMatrix(HMD::kLeftEye));
+      right_eye_->set_view_projection(hmd_->ViewProjectionMatrix(HMD::kRightEye));
     }
 
-    renderer_->Render(left_eye_, compositor_->render_block_list(), left_eye_->view_projection().get());
-    renderer_->Render(right_eye_, compositor_->render_block_list(), right_eye_->view_projection().get());
+    renderer_->Render(left_eye_, compositor_->render_block_list());
+    renderer_->Render(right_eye_, compositor_->render_block_list());
 
     if (with_hmd_) {
       hmd_->Submit(left_eye_, right_eye_);

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -84,10 +84,10 @@ bool Main::Init()
   } else {
     renderWidth = 320;
     renderHeight = 320;
+    SetEyeProjection();
   }
   if (left_eye_->Init(renderWidth, renderHeight) == false) return false;
   if (right_eye_->Init(renderWidth, renderHeight) == false) return false;
-  SetEyeProjection();
 
   if (head_->InitGL() == false) return false;
 

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -91,10 +91,6 @@ bool Main::Init()
 
   if (head_->InitGL() == false) return false;
 
-  if (with_hmd_) {
-    if (hmd_->InitGL() == false) return false;
-  }
-
   return true;
 }
 

--- a/compositor/meson.build
+++ b/compositor/meson.build
@@ -1,6 +1,7 @@
 dep_compositor = [
   libz11_public_dep,
   dependency('sdl2'),
+  dependency('openvr'),
   dependency('glew'),
 ]
 
@@ -12,6 +13,8 @@ src_compositor = [
   'renderer.h',
   'sdl.cc',
   'sdl.h',
+  'hmd.cc',
+  'hmd.h',
   'shader.cc',
   'shader.h',
 ]

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -34,7 +34,7 @@ bool Renderer::Init()
   return true;
 }
 
-void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list, const float *view_projection)
+void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list)
 {
   z11::List<z11::RenderBlock> *block = render_block_list->next();
 
@@ -49,7 +49,7 @@ void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list, 
 
   glEnable(GL_DEPTH_TEST);
   glUseProgram(default_shader_.id());
-  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, view_projection);
+  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->view_projection().get());
   do {
     glBindVertexArray(block->data()->vertex_array_object());
     // fprintf(stdout, "DrawArrays\n");

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -48,26 +48,27 @@ void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list)
   if (render_block_list->Empty()) {
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glDisable(GL_MULTISAMPLE);
-  } else {
-    glEnable(GL_DEPTH_TEST);
-    glUseProgram(default_shader_.id());
-    glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->view_projection().get());
-    do {
-      glBindVertexArray(block->data()->vertex_array_object());
-      glDrawArrays(GL_LINES, 0, block->data()->GetDataSize() / (sizeof(float) * 3));
-      glBindVertexArray(0);
-      block = block->next();
-    } while (!block->Head());
-    glUseProgram(0);
-
-    glBindFramebuffer(GL_FRAMEBUFFER, 0);
-    glDisable(GL_MULTISAMPLE);
-
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, eye->framebuffer_id());
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, eye->resolve_framebuffer_id());
-    glBlitFramebuffer(0, 0, eye->width(), eye->height(), 0, 0, eye->width(), eye->height(),
-                      GL_COLOR_BUFFER_BIT, GL_LINEAR);
-    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    return;
   }
+
+  glEnable(GL_DEPTH_TEST);
+  glUseProgram(default_shader_.id());
+  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->view_projection().get());
+  do {
+    glBindVertexArray(block->data()->vertex_array_object());
+    glDrawArrays(GL_LINES, 0, block->data()->GetDataSize() / (sizeof(float) * 3));
+    glBindVertexArray(0);
+    block = block->next();
+  } while (!block->Head());
+  glUseProgram(0);
+
+  glBindFramebuffer(GL_FRAMEBUFFER, 0);
+  glDisable(GL_MULTISAMPLE);
+
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, eye->framebuffer_id());
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, eye->resolve_framebuffer_id());
+  glBlitFramebuffer(0, 0, eye->width(), eye->height(), 0, 0, eye->width(), eye->height(), GL_COLOR_BUFFER_BIT,
+                    GL_LINEAR);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 }

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -62,7 +62,7 @@ clean:
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glDisable(GL_MULTISAMPLE);
   glBindFramebuffer(GL_READ_FRAMEBUFFER, eye->framebuffer_id());
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, eye->copy_framebuffer_id());
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, eye->resolve_framebuffer_id());
   glBlitFramebuffer(0, 0, eye->width(), eye->height(), 0, 0, eye->width(), eye->height(), GL_COLOR_BUFFER_BIT,
                     GL_LINEAR);
   glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -52,7 +52,6 @@ void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list)
   glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->view_projection().get());
   do {
     glBindVertexArray(block->data()->vertex_array_object());
-    // fprintf(stdout, "DrawArrays\n");
     glDrawArrays(GL_LINES, 0, block->data()->GetDataSize() / (sizeof(float) * 3));
     glBindVertexArray(0);
     block = block->next();

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -34,7 +34,8 @@ bool Renderer::Init()
   return true;
 }
 
-void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list)
+void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list,
+                      const float *projection_matrix)
 {
   z11::List<z11::RenderBlock> *block = render_block_list->next();
 
@@ -47,9 +48,10 @@ void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list)
 
   glEnable(GL_DEPTH_TEST);
   glUseProgram(default_shader_.id());
-  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->projection().get());
+  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, projection_matrix);
   do {
     glBindVertexArray(block->data()->vertex_array_object());
+    // fprintf(stdout, "DrawArrays\n");
     glDrawArrays(GL_LINES, 0, block->data()->GetDataSize() / (sizeof(float) * 3));
     glBindVertexArray(0);
     block = block->next();

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -45,26 +45,29 @@ void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list)
   glViewport(0, 0, eye->width(), eye->height());
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-  if (render_block_list->Empty()) goto clean;
+  if (render_block_list->Empty()) {
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glDisable(GL_MULTISAMPLE);
+  } else {
+    glEnable(GL_DEPTH_TEST);
+    glUseProgram(default_shader_.id());
+    glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->view_projection().get());
+    do {
+      glBindVertexArray(block->data()->vertex_array_object());
+      glDrawArrays(GL_LINES, 0, block->data()->GetDataSize() / (sizeof(float) * 3));
+      glBindVertexArray(0);
+      block = block->next();
+    } while (!block->Head());
+    glUseProgram(0);
 
-  glEnable(GL_DEPTH_TEST);
-  glUseProgram(default_shader_.id());
-  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->view_projection().get());
-  do {
-    glBindVertexArray(block->data()->vertex_array_object());
-    glDrawArrays(GL_LINES, 0, block->data()->GetDataSize() / (sizeof(float) * 3));
-    glBindVertexArray(0);
-    block = block->next();
-  } while (!block->Head());
-  glUseProgram(0);
+    glBindFramebuffer(GL_FRAMEBUFFER, 0);
+    glDisable(GL_MULTISAMPLE);
 
-clean:
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
-  glDisable(GL_MULTISAMPLE);
-  glBindFramebuffer(GL_READ_FRAMEBUFFER, eye->framebuffer_id());
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, eye->resolve_framebuffer_id());
-  glBlitFramebuffer(0, 0, eye->width(), eye->height(), 0, 0, eye->width(), eye->height(), GL_COLOR_BUFFER_BIT,
-                    GL_LINEAR);
-  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, eye->framebuffer_id());
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, eye->resolve_framebuffer_id());
+    glBlitFramebuffer(0, 0, eye->width(), eye->height(), 0, 0, eye->width(), eye->height(),
+                      GL_COLOR_BUFFER_BIT, GL_LINEAR);
+    glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+    glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
+  }
 }

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -34,10 +34,11 @@ bool Renderer::Init()
   return true;
 }
 
-void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list,
-                      const float *projection_matrix)
+void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list, const float *view_projection)
 {
   z11::List<z11::RenderBlock> *block = render_block_list->next();
+
+  glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
   glEnable(GL_MULTISAMPLE);
   glBindFramebuffer(GL_FRAMEBUFFER, eye->framebuffer_id());
@@ -48,7 +49,7 @@ void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list,
 
   glEnable(GL_DEPTH_TEST);
   glUseProgram(default_shader_.id());
-  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, projection_matrix);
+  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, view_projection);
   do {
     glBindVertexArray(block->data()->vertex_array_object());
     // fprintf(stdout, "DrawArrays\n");
@@ -61,4 +62,10 @@ void Renderer::Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list,
 clean:
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   glDisable(GL_MULTISAMPLE);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, eye->framebuffer_id());
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, eye->copy_framebuffer_id());
+  glBlitFramebuffer(0, 0, eye->width(), eye->height(), 0, 0, eye->width(), eye->height(), GL_COLOR_BUFFER_BIT,
+                    GL_LINEAR);
+  glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
 }

--- a/compositor/renderer.h
+++ b/compositor/renderer.h
@@ -11,7 +11,7 @@ class Renderer
 {
  public:
   bool Init();
-  void Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list);
+  void Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list, const float *projection_matrix);
 
  private:
   Shader default_shader_;

--- a/compositor/renderer.h
+++ b/compositor/renderer.h
@@ -11,7 +11,7 @@ class Renderer
 {
  public:
   bool Init();
-  void Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list, const float *view_projection_matrix);
+  void Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list);
 
  private:
   Shader default_shader_;

--- a/compositor/renderer.h
+++ b/compositor/renderer.h
@@ -11,7 +11,7 @@ class Renderer
 {
  public:
   bool Init();
-  void Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list, const float *projection_matrix);
+  void Render(Eye *eye, z11::List<z11::RenderBlock> *render_block_list, const float *view_projection_matrix);
 
  private:
   Shader default_shader_;

--- a/compositor/sdl.cc
+++ b/compositor/sdl.cc
@@ -33,34 +33,8 @@ bool SDLHead::Init()
   return true;
 }
 
-bool SDLHead::InitGL(Eye *left_eye, Eye *right_eye)
+bool SDLHead::InitGL()
 {
-  // create framebuffer for left eye copy
-  glGenFramebuffers(1, &left_copy_framebuffer_id_);
-  glBindFramebuffer(GL_FRAMEBUFFER, left_copy_framebuffer_id_);
-
-  glGenTextures(1, &left_copy_texture_id_);
-  glBindTexture(GL_TEXTURE_2D, left_copy_texture_id_);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, left_eye->width(), left_eye->height(), 0, GL_RGBA,
-               GL_UNSIGNED_BYTE, nullptr);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, left_copy_texture_id_, 0);
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-  // create framebuffer for right eye copy
-  glGenFramebuffers(1, &right_copy_framebuffer_id_);
-  glBindFramebuffer(GL_FRAMEBUFFER, right_copy_framebuffer_id_);
-
-  glGenTextures(1, &right_copy_texture_id_);
-  glBindTexture(GL_TEXTURE_2D, right_copy_texture_id_);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, 0);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, right_eye->width(), right_eye->height(), 0, GL_RGBA,
-               GL_UNSIGNED_BYTE, nullptr);
-  glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, right_copy_texture_id_, 0);
-  glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
   // prepare shader
   if (default_shader_.Init(  //
           "CompanionWindow",
@@ -140,7 +114,7 @@ void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
 {
   // copy left eye
   glBindFramebuffer(GL_READ_FRAMEBUFFER, left_eye->framebuffer_id());
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, left_copy_framebuffer_id_);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, left_eye->copy_framebuffer_id());
 
   glBlitFramebuffer(0, 0, left_eye->width(), left_eye->height(), 0, 0, left_eye->width(), left_eye->height(),
                     GL_COLOR_BUFFER_BIT, GL_LINEAR);
@@ -150,7 +124,7 @@ void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
 
   // copy right eye
   glBindFramebuffer(GL_READ_FRAMEBUFFER, right_eye->framebuffer_id());
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, right_copy_framebuffer_id_);
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, right_eye->copy_framebuffer_id());
 
   glBlitFramebuffer(0, 0, right_eye->width(), right_eye->height(), 0, 0, right_eye->width(),
                     right_eye->height(), GL_COLOR_BUFFER_BIT, GL_LINEAR);
@@ -165,14 +139,14 @@ void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
   glBindVertexArray(vertex_array_object_);
   glUseProgram(default_shader_.id());
 
-  glBindTexture(GL_TEXTURE_2D, left_copy_texture_id_);
+  glBindTexture(GL_TEXTURE_2D, left_eye->copy_texture_id());
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glDrawElements(GL_TRIANGLES, index_size_ / 2, GL_UNSIGNED_SHORT, 0);
 
-  glBindTexture(GL_TEXTURE_2D, right_copy_texture_id_);
+  glBindTexture(GL_TEXTURE_2D, right_eye->copy_texture_id());
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/compositor/sdl.cc
+++ b/compositor/sdl.cc
@@ -14,8 +14,8 @@ bool SDLHead::Init()
 
   int windowPosX = 700;
   int windowPosY = 100;
-  int windowWidth = 640;
-  int windowHeight = 320;
+  window_width_ = 640;
+  window_height_ = 320;
 
   Uint32 windowFlags = SDL_WINDOW_OPENGL | SDL_WINDOW_SHOWN;
 
@@ -24,7 +24,7 @@ bool SDLHead::Init()
   SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 
   window_ =
-      SDL_CreateWindow("z11 sdl window", windowPosX, windowPosY, windowWidth, windowHeight, windowFlags);
+      SDL_CreateWindow("z11 sdl window", windowPosX, windowPosY, window_width_, window_height_, windowFlags);
   if (window_ == nullptr) return false;
 
   gl_context_ = SDL_GL_CreateContext(window_);
@@ -134,7 +134,7 @@ void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
 
   // draw from copied buffer to default frame buffer
   glDisable(GL_DEPTH_TEST);
-  glViewport(0, 0, left_eye->width() + right_eye->width(), left_eye->height());
+  glViewport(0, 0, window_width_, window_height_);
 
   glBindVertexArray(vertex_array_object_);
   glUseProgram(default_shader_.id());

--- a/compositor/sdl.cc
+++ b/compositor/sdl.cc
@@ -114,7 +114,7 @@ void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
 {
   // copy left eye
   glBindFramebuffer(GL_READ_FRAMEBUFFER, left_eye->framebuffer_id());
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, left_eye->copy_framebuffer_id());
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, left_eye->resolve_framebuffer_id());
 
   glBlitFramebuffer(0, 0, left_eye->width(), left_eye->height(), 0, 0, left_eye->width(), left_eye->height(),
                     GL_COLOR_BUFFER_BIT, GL_LINEAR);
@@ -124,7 +124,7 @@ void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
 
   // copy right eye
   glBindFramebuffer(GL_READ_FRAMEBUFFER, right_eye->framebuffer_id());
-  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, right_eye->copy_framebuffer_id());
+  glBindFramebuffer(GL_DRAW_FRAMEBUFFER, right_eye->resolve_framebuffer_id());
 
   glBlitFramebuffer(0, 0, right_eye->width(), right_eye->height(), 0, 0, right_eye->width(),
                     right_eye->height(), GL_COLOR_BUFFER_BIT, GL_LINEAR);
@@ -139,14 +139,14 @@ void SDLHead::Draw(Eye *left_eye, Eye *right_eye)
   glBindVertexArray(vertex_array_object_);
   glUseProgram(default_shader_.id());
 
-  glBindTexture(GL_TEXTURE_2D, left_eye->copy_texture_id());
+  glBindTexture(GL_TEXTURE_2D, left_eye->resolve_texture_id());
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glDrawElements(GL_TRIANGLES, index_size_ / 2, GL_UNSIGNED_SHORT, 0);
 
-  glBindTexture(GL_TEXTURE_2D, right_eye->copy_texture_id());
+  glBindTexture(GL_TEXTURE_2D, right_eye->resolve_texture_id());
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);

--- a/compositor/sdl.h
+++ b/compositor/sdl.h
@@ -17,7 +17,7 @@ class SDLHead
 {
  public:
   bool Init();
-  bool InitGL(Eye *left_eye, Eye *right_eye);
+  bool InitGL();
   bool ProcessEvents();
   void Draw(Eye *left_eye, Eye *right_eye);
   void Swap();
@@ -26,10 +26,6 @@ class SDLHead
  private:
   SDL_Window *window_;
   SDL_GLContext gl_context_;
-  GLuint left_copy_framebuffer_id_;
-  GLuint left_copy_texture_id_;
-  GLuint right_copy_framebuffer_id_;
-  GLuint right_copy_texture_id_;
   uint32_t index_size_;
   GLuint vertex_array_object_;
   GLuint vertex_buffer_;

--- a/compositor/sdl.h
+++ b/compositor/sdl.h
@@ -26,6 +26,8 @@ class SDLHead
  private:
   SDL_Window *window_;
   SDL_GLContext gl_context_;
+  uint32_t window_width_;
+  uint32_t window_height_;
   uint32_t index_size_;
   GLuint vertex_array_object_;
   GLuint vertex_buffer_;


### PR DESCRIPTION
- [x] HMDを使わずに使えるようにOptionをつける
- [x] SDLHeadの `*_copy_framebuffer_id_` , `*_copy_texture_id_` をEyeに移行する
- [x] Projection MatrixをHMD用, SDL Window用で分ける
- [x] HMDに描画している内容とSDL Windowに描画されている内容を一致させる
- [x] モデルの軸の方向とHMDの描画方向を調整する