### PR TITLE
Create vertex buffer object

### DIFF
--- a/compositor/z_server.cc
+++ b/compositor/z_server.cc
@@ -6,11 +6,16 @@
 bool ZServer::Init()
 {
   const char* socket;
+  struct z_gl* gl;
+
   display_ = wl_display_create();
   loop_ = wl_display_get_event_loop(display_);
 
   compositor_ = z_compositor_create(display_);
   if (compositor_ == NULL) return false;
+
+  gl = z_gl_create(display_);
+  if (gl == NULL) return false;
 
   wl_display_init_shm(display_);
 

--- a/include/libz11.h
+++ b/include/libz11.h
@@ -21,6 +21,11 @@ void z_render_block_draw(struct z_render_block* render_block);
 
 struct z_render_block* z_render_block_from_link(struct wl_list* link);
 
+/* z_gl */
+struct z_gl;
+
+struct z_gl* z_gl_create(struct wl_display* display);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libz11/compositor.c
+++ b/libz11/compositor.c
@@ -4,7 +4,6 @@
 #include "z11-server-protocol.h"
 
 struct z_compositor {
-  struct wl_display* display;
   struct wl_list list;
 };
 
@@ -57,7 +56,6 @@ struct z_compositor* z_compositor_create(struct wl_display* display)
   compositor = zalloc(sizeof *compositor);
   if (compositor == NULL) goto fail;
 
-  compositor->display = display;
   wl_list_init(&compositor->list);
 
   if (wl_global_create(display, &z11_compositor_interface, 1, compositor, z_compositor_bind) == NULL)

--- a/libz11/gl.c
+++ b/libz11/gl.c
@@ -1,0 +1,56 @@
+#include <wayland-server.h>
+
+#include "internal.h"
+#include "z11-server-protocol.h"
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+struct z_gl {};
+#pragma GCC diagnostic pop
+
+static void z_gl_protocol_create_vertex_buffer(struct wl_client* client, struct wl_resource* resource,
+                                               uint32_t id)
+{
+  UNUSED(resource);
+  struct z_gl_vertex_buffer* gl_vertex_buffer;
+
+  gl_vertex_buffer = z_gl_vertex_buffer_create(client, id);
+  if (gl_vertex_buffer == NULL) {
+    // TODO: error log
+  }
+}
+
+static const struct z11_gl_interface z_gl_interface = {
+    .create_vertex_buffer = z_gl_protocol_create_vertex_buffer,
+};
+
+static void z_gl_bind(struct wl_client* client, void* data, uint32_t version, uint32_t id)
+{
+  struct z_gl* gl = data;
+  struct wl_resource* resource;
+
+  resource = wl_resource_create(client, &z11_gl_interface, version, id);
+  if (resource == NULL) goto no_mem_resource;
+
+  wl_resource_set_implementation(resource, &z_gl_interface, gl, NULL);
+
+  return;
+
+no_mem_resource:
+  wl_client_post_no_memory(client);
+}
+
+struct z_gl* z_gl_create(struct wl_display* display)
+{
+  struct z_gl* gl;
+
+  gl = zalloc(sizeof *gl);
+  if (gl == NULL) goto fail;
+
+  if (wl_global_create(display, &z11_gl_interface, 1, gl, z_gl_bind) == NULL) goto fail;
+
+  return gl;
+
+fail:
+  return NULL;
+}

--- a/libz11/gl_vertex_buffer.c
+++ b/libz11/gl_vertex_buffer.c
@@ -1,0 +1,81 @@
+#include <GL/glew.h>
+
+#include "internal.h"
+#include "z11-server-protocol.h"
+
+void z_gl_vertex_buffer_destroy(struct z_gl_vertex_buffer *vertex_buffer);
+
+static void z_gl_vertex_buffer_handle_destroy(struct wl_resource *resource)
+{
+  struct z_gl_vertex_buffer *vertex_buffer = wl_resource_get_user_data(resource);
+
+  z_gl_vertex_buffer_destroy(vertex_buffer);
+}
+
+static void z_gl_vertex_buffer_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
+{
+  UNUSED(client);
+  struct z_gl_vertex_buffer *vertex_buffer = wl_resource_get_user_data(resource);
+
+  z_gl_vertex_buffer_destroy(vertex_buffer);
+}
+
+static void z_gl_vertex_buffer_protocol_allocate(struct wl_client *client, struct wl_resource *resource,
+                                                 int32_t size, struct wl_resource *raw_buffer)
+{
+  UNUSED(client);
+  struct z_gl_vertex_buffer *vertex_buffer = wl_resource_get_user_data(resource);
+
+  if (raw_buffer == NULL) {
+    glNamedBufferData(vertex_buffer->id, size, NULL, GL_STATIC_DRAW);
+  } else {
+    struct wl_shm_raw_buffer *shm_raw_buffer = wl_shm_raw_buffer_get(raw_buffer);
+    void *data = wl_shm_raw_buffer_get_data(shm_raw_buffer);
+    int32_t data_size = wl_shm_raw_buffer_get_size(shm_raw_buffer);
+    if (data_size < size) {
+      // TODO: Error handling
+      return;
+    }
+    glNamedBufferData(vertex_buffer->id, size, data, GL_STATIC_DRAW);
+  }
+  vertex_buffer->size = size;
+}
+
+static const struct z11_gl_vertex_buffer_interface z_gl_vertex_buffer_interface = {
+    .destroy = z_gl_vertex_buffer_protocol_destroy,
+    .allocate = z_gl_vertex_buffer_protocol_allocate,
+};
+
+struct z_gl_vertex_buffer *z_gl_vertex_buffer_create(struct wl_client *client, uint32_t id)
+{
+  struct z_gl_vertex_buffer *vertex_buffer;
+  struct wl_resource *resource;
+
+  vertex_buffer = zalloc(sizeof *vertex_buffer);
+  if (vertex_buffer == NULL) goto fail;
+
+  resource = wl_resource_create(client, &z11_gl_vertex_buffer_interface, 1, id);
+  if (resource == NULL) goto no_mem_resource;
+
+  glGenBuffers(1, &vertex_buffer->id);
+  wl_signal_init(&vertex_buffer->destroy_signal);
+
+  wl_resource_set_implementation(resource, &z_gl_vertex_buffer_interface, vertex_buffer,
+                                 z_gl_vertex_buffer_handle_destroy);
+
+  return vertex_buffer;
+
+no_mem_resource:
+  free(vertex_buffer);
+
+fail:
+  wl_client_post_no_memory(client);
+  return NULL;
+}
+
+void z_gl_vertex_buffer_destroy(struct z_gl_vertex_buffer *vertex_buffer)
+{
+  wl_signal_emit(&vertex_buffer->destroy_signal, vertex_buffer);
+  glDeleteBuffers(1, &vertex_buffer->id);
+  free(vertex_buffer);
+}

--- a/libz11/internal.h
+++ b/libz11/internal.h
@@ -5,8 +5,11 @@
 extern "C" {
 #endif
 
+#include <GL/glew.h>
 #include <libz11.h>
 #include <stdlib.h>
+
+#define UNUSED(x) ((void)x)
 
 /* helper function */
 inline void* zalloc(size_t size) { return calloc(1, size); }
@@ -14,6 +17,29 @@ inline void* zalloc(size_t size) { return calloc(1, size); }
 /* z_compositor */
 
 void z_compositor_append_render_block(struct z_compositor* compositor, struct z_render_block* render_block);
+
+/* z_gl_vertex_buffer */
+
+struct z_gl_vertex_buffer {
+  GLuint id;
+  int32_t size;
+  struct wl_signal destroy_signal;
+};
+
+struct z_gl_vertex_buffer* z_gl_vertex_buffer_create(struct wl_client* client, uint32_t id);
+
+/* z_render_block_state */
+
+struct z_render_block_state;
+
+struct z_render_block_state* z_render_block_state_create();
+
+void z_render_block_state_destroy(struct z_render_block_state* state);
+
+void z_render_block_state_attach_vertex_buffer(struct z_render_block_state* state,
+                                               struct z_gl_vertex_buffer* vertex_buffer);
+
+struct z_gl_vertex_buffer* z_render_block_state_get_vertex_buffer(struct z_render_block_state* state);
 
 /* z_render_block */
 

--- a/libz11/meson.build
+++ b/libz11/meson.build
@@ -5,7 +5,10 @@ deps_libz11 = [
 
 srcs_libz11 = files([
   'compositor.c',
+  'gl.c',
+  'gl_vertex_buffer.c',
   'render_block.c',
+  'render_block_state.c',
 ]) + [
   z11_protocol_c,
   z11_server_protocol_h,

--- a/libz11/render_block_state.c
+++ b/libz11/render_block_state.c
@@ -1,0 +1,56 @@
+#include "internal.h"
+
+struct z_render_block_state {
+  struct z_gl_vertex_buffer* vertex_buffer; /** nullable */
+  struct wl_listener vertex_buffer_destroy_listener;
+};
+
+static void z_render_block_state_vertex_buffer_destroy_signal_handler(struct wl_listener* listener,
+                                                                      void* data)
+{
+  UNUSED(data);
+  struct z_render_block_state* render_block_state;
+
+  render_block_state = wl_container_of(listener, render_block_state, vertex_buffer_destroy_listener);
+
+  render_block_state->vertex_buffer = NULL;
+}
+
+struct z_render_block_state* z_render_block_state_create()
+{
+  struct z_render_block_state* state;
+
+  state = zalloc(sizeof *state);
+  if (state == NULL) goto fail;
+
+  wl_list_init(&state->vertex_buffer_destroy_listener.link);
+  state->vertex_buffer_destroy_listener.notify = z_render_block_state_vertex_buffer_destroy_signal_handler;
+
+  return state;
+
+fail:
+  return NULL;
+}
+
+void z_render_block_state_destroy(struct z_render_block_state* state)
+{
+  wl_list_remove(&state->vertex_buffer_destroy_listener.link);
+  free(state);
+}
+
+void z_render_block_state_attach_vertex_buffer(struct z_render_block_state* state,
+                                               struct z_gl_vertex_buffer* vertex_buffer)
+{
+  wl_list_remove(&state->vertex_buffer_destroy_listener.link);
+  wl_signal_add(&vertex_buffer->destroy_signal, &state->vertex_buffer_destroy_listener);
+
+  state->vertex_buffer = vertex_buffer;
+}
+
+/**
+ * @return nullable
+ */
+struct z_gl_vertex_buffer* z_render_block_state_get_vertex_buffer(struct z_render_block_state* state)
+{
+  return state->vertex_buffer;
+}

--- a/protocol/z11.xml
+++ b/protocol/z11.xml
@@ -9,17 +9,49 @@
       <description summary="create new render block">TBD</description>
       <arg name="id" type="new_id" interface="z11_render_block" summary="the new render block" />
     </request>
-
   </interface>
 
   <interface name="z11_render_block" version="1">
     <description summary="set of information to render 3D object">TBD</description>
-    <request name="attach">
-      <description summary="attach raw buffer to the render block">TBD</description>
-      <arg name="raw_buffer" type="object" interface="wl_raw_buffer" allow-null="true" />
+
+    <request name="destroy" type="destructor">
+      <description summary="delete render block">TBD</description>
     </request>
+
+    <request name="attach_vertex_buffer">
+      <description summary="attach vertex buffer to the render block">TBD</description>
+      <arg name="vertex_buffer" type="object" interface="z11_gl_vertex_buffer"/>
+    </request>
+
     <request name="commit">
       <description summary="commit the render block">TBD</description>
+    </request>
+  </interface>
+
+  <interface name="z11_gl" version="1">
+    <description summary="Graphic library api">TBD</description>
+
+    <request name="create_vertex_buffer">
+      <description summary="Create a vertex buffer">TBD</description>
+      <arg name="id" type="new_id" interface="z11_gl_vertex_buffer" summary="the new vertex buffer" />
+    </request>
+  </interface>
+
+  <interface name="z11_gl_vertex_buffer" version="1">
+    <description summary="vertex buffer">TBD</description>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete vertex buffer">TBD</description>
+    </request>
+
+    <request name="allocate">
+      <description summary="allocate memory">
+        Allocate GPU memory for the vertex buffer. If memory has already been allocated, this request frees the memory.
+
+        When buffer is not null, we will copy the content of the buffer to the allocated memory.
+      </description>
+      <arg name="size" type="int" summary="specifies the size in bytes of the buffer's new data store"/>
+      <arg name="raw_buffer" type="object" interface="wl_raw_buffer" allow-null="true" summary="nullable"/>
     </request>
   </interface>
 </protocol>


### PR DESCRIPTION
リファクタ系続きで申し訳ないけど、Textureとか使う下準備です。

Vertex bufferをオブジェクトとしてちゃんと定義して、クライアント側で作成できるようにした。

今まではraw_bufferオブジェクトをrender_blockにattachして、内部でVertex bufferオブジェクトを作っていたけど、
ユーザが好きにvertex bufferをつくって、raw_bufferを用いてそこにデータを流し込み、render_blockにはvertex bufferをattachするようにした。
これは一つのvertex bufferが複数のrender blockで用いられることも想定している。
(一つのvertex bufferに対して陰を描画するためとオブジェクトそのものを描画するためと、・・・みたいに複数のshaderやtextureを使うことがあるらしい。)

あと、render_blockにcurrent state / next stateを用意して、vertex buffer, texture, shaderなどを変更する時に一度に変更を適用(commit)できるようにした。一つ一つバラバラに更新するとサーバー側のpollingの分かれ目に入って、予期せぬことが起きる可能性が考えられるので。
ただし、textureやshaderなどを変える必要がなくvertex bufferの中身だけ書き換えるような場合はcommitせずにvertex bufferの中身を書き換えるrequestだけで描画が更新される。simple-boxはそのような実装になっている。