### PR TITLE
Enable client to create shader program

### DIFF
--- a/clients/simple_box.c
+++ b/clients/simple_box.c
@@ -150,6 +150,12 @@ static void paint_frame(Line *out, float x, float y, float z, float theta)
   out->end = H;
 }
 
+const char *vertex_shader;
+
+const char *red_fragment_shader;
+
+const char *orange_fragment_shader;
+
 int main(int argc, char const *argv[])
 {
   int x = 0;
@@ -207,12 +213,20 @@ int main(int argc, char const *argv[])
   struct z11_gl_vertex_buffer *triangle_vertex_buffer = z11_gl_create_vertex_buffer(gl);
   z11_gl_vertex_buffer_allocate(triangle_vertex_buffer, size_of_triangles, triangle_buffer);
 
+  struct z11_gl_shader_program *frame_shader_program =
+      z11_gl_create_shader_program(gl, vertex_shader, red_fragment_shader);
+
+  struct z11_gl_shader_program *plane_shader_program =
+      z11_gl_create_shader_program(gl, vertex_shader, orange_fragment_shader);
+
   struct z11_render_block *frame_render_block = z11_compositor_create_render_block(compositor);
   z11_render_block_attach_vertex_buffer(frame_render_block, line_vertex_buffer);
+  z11_render_block_attach_shader_program(frame_render_block, frame_shader_program);
   z11_render_block_commit(frame_render_block);
 
   struct z11_render_block *plane_render_block = z11_compositor_create_render_block(compositor);
   z11_render_block_attach_vertex_buffer(plane_render_block, triangle_vertex_buffer);
+  z11_render_block_attach_shader_program(plane_render_block, plane_shader_program);
   z11_render_block_set_topology(plane_render_block, Z11_GL_TOPOLOGY_TRIANGLES);
   z11_render_block_commit(plane_render_block);
 
@@ -238,3 +252,34 @@ int main(int argc, char const *argv[])
 
   return 0;
 }
+
+const char *vertex_shader =
+    "#version 410\n"
+    "uniform mat4 matrix;\n"
+    "layout(location = 0) in vec4 position;\n"
+    "layout(location = 1) in vec2 v2UVcoordsIn;\n"
+    "layout(location = 2) in vec3 v3NormalIn;\n"
+    "out vec2 v2UVcoords;\n"
+    "void main()\n"
+    "{\n"
+    "  v2UVcoords = v2UVcoordsIn;\n"
+    "  gl_Position = matrix * position;\n"
+    "}\n";
+
+const char *red_fragment_shader =
+    "#version 410 core\n"
+    "in vec2 v2UVcoords;\n"
+    "out vec4 outputColor;\n"
+    "void main()\n"
+    "{\n"
+    "  outputColor = vec4(1.0, 0.0, 0.0, 1.0);\n"
+    "}\n";
+
+const char *orange_fragment_shader =
+    "#version 410 core\n"
+    "in vec2 v2UVcoords;\n"
+    "out vec4 outputColor;\n"
+    "void main()\n"
+    "{\n"
+    "  outputColor = vec4(1.0, 0.647, 0.0, 1.0);\n"
+    "}\n";

--- a/compositor/main.cc
+++ b/compositor/main.cc
@@ -72,7 +72,6 @@ bool Main::Init()
   glGetError();
 
   renderer_ = new Renderer();
-  if (renderer_->Init() == false) return false;
 
   left_eye_ = new Eye();
   right_eye_ = new Eye();

--- a/compositor/renderer.cc
+++ b/compositor/renderer.cc
@@ -2,38 +2,6 @@
 
 #include <libz11.h>
 
-bool Renderer::Init()
-{
-  if (default_shader_.Init(  //
-          "Scene",
-
-          // Vertex Shader
-          "#version 410\n"
-          "uniform mat4 matrix;\n"
-          "layout(location = 0) in vec4 position;\n"
-          "layout(location = 1) in vec2 v2UVcoordsIn;\n"
-          "layout(location = 2) in vec3 v3NormalIn;\n"
-          "out vec2 v2UVcoords;\n"
-          "void main()\n"
-          "{\n"
-          "  v2UVcoords = v2UVcoordsIn;\n"
-          "  gl_Position = matrix * position;\n"
-          "}\n",
-
-          // Fragment Shader
-          "#version 410 core\n"
-          "in vec2 v2UVcoords;\n"
-          "out vec4 outputColor;\n"
-          "void main()\n"
-          "{\n"
-          "  outputColor = vec4(1.0, 0.0, 0.0, 1.0);"
-          "}\n") == false)
-    return false;
-  default_shader_matrix_location_ = glGetUniformLocation(default_shader_.id(), "matrix");
-
-  return true;
-}
-
 void Renderer::Render(Eye *eye, ZServer::RenderBlockIterator *render_block_iterator)
 {
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -51,10 +19,8 @@ void Renderer::Render(Eye *eye, ZServer::RenderBlockIterator *render_block_itera
   }
 
   glEnable(GL_DEPTH_TEST);
-  glUseProgram(default_shader_.id());
-  glUniformMatrix4fv(default_shader_matrix_location_, 1, GL_FALSE, eye->view_projection().get());
   do {
-    z_render_block_draw(render_block);
+    z_render_block_draw(render_block, eye->view_projection().get());
     render_block = render_block_iterator->Next();
   } while (render_block != nullptr);
   glUseProgram(0);

--- a/compositor/renderer.h
+++ b/compositor/renderer.h
@@ -11,12 +11,7 @@
 class Renderer
 {
  public:
-  bool Init();
   void Render(Eye *eye, ZServer::RenderBlockIterator *render_block_iterator);
-
- private:
-  Shader default_shader_;
-  GLint default_shader_matrix_location_;
 };
 
 #endif  // Z11_RENDERER_H

--- a/include/libz11.h
+++ b/include/libz11.h
@@ -17,7 +17,7 @@ struct wl_list* z_compositor_get_render_block_list(struct z_compositor* composit
 /* z11_render_block */
 struct z_render_block;
 
-void z_render_block_draw(struct z_render_block* render_block);
+void z_render_block_draw(struct z_render_block* render_block, const float* view_projection_matrix);
 
 struct z_render_block* z_render_block_from_link(struct wl_list* link);
 

--- a/libz11/gl.c
+++ b/libz11/gl.c
@@ -20,8 +20,22 @@ static void z_gl_protocol_create_vertex_buffer(struct wl_client* client, struct 
   }
 }
 
+static void z_gl_protocol_create_shader_program(struct wl_client* client, struct wl_resource* resource,
+                                                uint32_t id, const char* vertex_shader_source,
+                                                const char* fragment_shader_source)
+{
+  UNUSED(resource);
+  struct z_gl_shader_program* shader_program;
+
+  shader_program = z_gl_shader_program_create(client, id, vertex_shader_source, fragment_shader_source);
+  if (shader_program == NULL) {
+    // TODO: error log
+  }
+}
+
 static const struct z11_gl_interface z_gl_interface = {
     .create_vertex_buffer = z_gl_protocol_create_vertex_buffer,
+    .create_shader_program = z_gl_protocol_create_shader_program,
 };
 
 static void z_gl_bind(struct wl_client* client, void* data, uint32_t version, uint32_t id)

--- a/libz11/gl_shader_program.c
+++ b/libz11/gl_shader_program.c
@@ -1,0 +1,137 @@
+#include <GL/glew.h>
+#include <stdio.h>
+#include <wayland-server.h>
+
+#include "internal.h"
+
+struct z_gl_shader_program {
+  GLuint id;
+  struct wl_signal destroy_signal;
+};
+
+void z_gl_shader_program_destroy(struct z_gl_shader_program* shader_program);
+
+static void z_gl_shader_program_handle_destroy(struct wl_resource* resource)
+{
+  struct z_gl_shader_program* shader_program = wl_resource_get_user_data(resource);
+
+  z_gl_shader_program_destroy(shader_program);
+}
+
+static void z_gl_shader_program_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
+{
+  UNUSED(client);
+  struct z_gl_shader_program* shader_program = wl_resource_get_user_data(resource);
+
+  z_gl_shader_program_destroy(shader_program);
+}
+
+static const struct z11_gl_shader_program_interface z_gl_shader_program_interface = {
+    .destroy = z_gl_shader_program_protocol_destroy,
+};
+
+/**
+ * Be sure that each source string is null termintaed
+ * @param vertex_shader_source null terminated vertex shader source string
+ * @param fragment_shader_source null terminated fragment shader source string
+ * @return 0 when compilation fails
+ */
+static uint32_t z11_gl_shader_program_compile_shaders(GLuint program_id, const char* vertex_shader_source,
+                                                      const char* fragment_shader_source)
+{
+  GLuint vertex_shader = glCreateShader(GL_VERTEX_SHADER);
+  glShaderSource(vertex_shader, 1, &vertex_shader_source, NULL);
+  glCompileShader(vertex_shader);
+
+  GLint vertex_shader_compiled = GL_FALSE;
+  glGetShaderiv(vertex_shader, GL_COMPILE_STATUS, &vertex_shader_compiled);
+  if (vertex_shader_compiled != GL_TRUE) {
+    glDeleteShader(vertex_shader);
+    return 0;
+  }
+  glAttachShader(program_id, vertex_shader);
+  glDeleteShader(vertex_shader);
+
+  GLuint fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
+  glShaderSource(fragment_shader, 1, &fragment_shader_source, NULL);
+  glCompileShader(fragment_shader);
+
+  GLint fragment_shader_compiled = GL_FALSE;
+  glGetShaderiv(fragment_shader, GL_COMPILE_STATUS, &fragment_shader_compiled);
+  if (fragment_shader_compiled != GL_TRUE) {
+    glDeleteShader(fragment_shader);
+    return 0;
+  }
+  glAttachShader(program_id, fragment_shader);
+  glDeleteShader(fragment_shader);
+
+  glLinkProgram(program_id);
+
+  GLint program_success = GL_TRUE;
+  glGetProgramiv(program_id, GL_LINK_STATUS, &program_success);
+  if (program_success != GL_TRUE) {
+    return 0;
+  }
+
+  glUseProgram(program_id);
+  glUseProgram(0);
+
+  return program_id;
+}
+
+struct z_gl_shader_program* z_gl_shader_program_create(struct wl_client* client, uint32_t id,
+                                                       const char* vertex_shader_source,
+                                                       const char* fragment_shader_source)
+{
+  struct z_gl_shader_program* shader_program;
+  struct wl_resource* resource;
+
+  shader_program = zalloc(sizeof *shader_program);
+  if (shader_program == NULL) {
+    wl_client_post_no_memory(client);
+    goto no_mem_shader_program;
+  }
+
+  resource = wl_resource_create(client, &z11_gl_shader_program_interface, 1, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    goto no_mem_resource;
+  }
+
+  wl_resource_set_implementation(resource, &z_gl_shader_program_interface, shader_program,
+                                 z_gl_shader_program_handle_destroy);
+
+  wl_signal_init(&shader_program->destroy_signal);
+
+  shader_program->id = glCreateProgram();
+  if (shader_program->id == 0 || z11_gl_shader_program_compile_shaders(
+                                     shader_program->id, vertex_shader_source, fragment_shader_source) == 0) {
+    wl_resource_post_error(resource, Z11_GL_SHADER_PROGRAM_ERROR_COMPILATION_ERROR,
+                           "failed to compile shaders");
+    wl_resource_destroy(resource);
+    return NULL;
+  }
+
+  return shader_program;
+
+no_mem_resource:
+  free(shader_program);
+
+no_mem_shader_program:
+  return NULL;
+}
+
+void z_gl_shader_program_destroy(struct z_gl_shader_program* shader_program)
+{
+  wl_signal_emit(&shader_program->destroy_signal, shader_program);
+  glDeleteProgram(shader_program->id);
+  free(shader_program);
+}
+
+void z_gl_shader_program_add_destroy_signal_handler(struct z_gl_shader_program* shader_program,
+                                                    struct wl_listener* listener)
+{
+  wl_signal_add(&shader_program->destroy_signal, listener);
+}
+
+GLuint z_gl_shader_program_get_id(struct z_gl_shader_program* shader_program) { return shader_program->id; }

--- a/libz11/internal.h
+++ b/libz11/internal.h
@@ -30,6 +30,19 @@ struct z_gl_vertex_buffer {
 
 struct z_gl_vertex_buffer* z_gl_vertex_buffer_create(struct wl_client* client, uint32_t id);
 
+/* z_gl_shader_program */
+
+struct z_gl_shader_program;
+
+struct z_gl_shader_program* z_gl_shader_program_create(struct wl_client* client, uint32_t id,
+                                                       const char* vertex_shader_source,
+                                                       const char* fragment_shader_source);
+
+void z_gl_shader_program_add_destroy_signal_handler(struct z_gl_shader_program* shader_program,
+                                                    struct wl_listener* listener);
+
+GLuint z_gl_shader_program_get_id(struct z_gl_shader_program* shader_program);
+
 /* z_render_block_state */
 
 struct z_render_block_state;
@@ -42,6 +55,11 @@ void z_render_block_state_attach_vertex_buffer(struct z_render_block_state* stat
                                                struct z_gl_vertex_buffer* vertex_buffer);
 
 struct z_gl_vertex_buffer* z_render_block_state_get_vertex_buffer(struct z_render_block_state* state);
+
+void z_render_block_state_attach_shader_program(struct z_render_block_state* state,
+                                                struct z_gl_shader_program* shader_program);
+
+struct z_gl_shader_program* z_render_block_state_get_shader_program(struct z_render_block_state* state);
 
 enum z11_gl_topology z_render_block_state_get_topology(struct z_render_block_state* state);
 

--- a/libz11/meson.build
+++ b/libz11/meson.build
@@ -6,6 +6,7 @@ deps_libz11 = [
 srcs_libz11 = files([
   'compositor.c',
   'gl.c',
+  'gl_shader_program.c',
   'gl_vertex_buffer.c',
   'render_block.c',
   'render_block_state.c',

--- a/libz11/render_block.c
+++ b/libz11/render_block.c
@@ -40,6 +40,17 @@ static void z_render_block_protocol_attach_vertex_buffer(struct wl_client* clien
   z_render_block_state_attach_vertex_buffer(render_block->next_state, vertex_buffer);
 }
 
+static void z_render_block_protocol_attach_shader_program(struct wl_client* client,
+                                                          struct wl_resource* resource,
+                                                          struct wl_resource* shader_program_resource)
+{
+  UNUSED(client);
+  struct z_render_block* render_block = wl_resource_get_user_data(resource);
+  struct z_gl_shader_program* shader_program = wl_resource_get_user_data(shader_program_resource);
+
+  z_render_block_state_attach_shader_program(render_block->next_state, shader_program);
+}
+
 static void z_render_block_protocol_set_topology(struct wl_client* client, struct wl_resource* resource,
                                                  enum z11_gl_topology topology)
 {
@@ -74,6 +85,7 @@ static void z_render_block_protocol_commit(struct wl_client* client, struct wl_r
 static const struct z11_render_block_interface z_render_block_interface = {
     .destroy = z_render_block_protocol_destroy,
     .attach_vertex_buffer = z_render_block_protocol_attach_vertex_buffer,
+    .attach_shader_program = z_render_block_protocol_attach_shader_program,
     .set_topology = z_render_block_protocol_set_topology,
     .commit = z_render_block_protocol_commit,
 };
@@ -94,14 +106,25 @@ static GLenum z_render_block_get_current_state_opengl_topology_mode(struct z_ren
 
 struct wl_list* z_render_block_get_link(struct z_render_block* render_block) { return &render_block->link; }
 
-void z_render_block_draw(struct z_render_block* render_block)
+/**
+ * call glUseProgram(0) after all render blocks are processed.
+ */
+void z_render_block_draw(struct z_render_block* render_block, const float* view_projection_matrix)
 {
   struct z_gl_vertex_buffer* vertex_buffer =
       z_render_block_state_get_vertex_buffer(render_block->current_state);
-  if (vertex_buffer == NULL) return;
+  struct z_gl_shader_program* shader_program =
+      z_render_block_state_get_shader_program(render_block->current_state);
+
+  if (vertex_buffer == NULL || shader_program == NULL) return;
 
   GLenum mode = z_render_block_get_current_state_opengl_topology_mode(render_block);
+  GLuint program = z_gl_shader_program_get_id(shader_program);
 
+  glUseProgram(program);
+  GLint view_projection_matrix_location =
+      glGetUniformLocation(program, "matrix");  // TODO: Be customizable by client
+  glUniformMatrix4fv(view_projection_matrix_location, 1, GL_FALSE, view_projection_matrix);
   glBindVertexArray(render_block->vertex_array_object);
   glDrawArrays(mode, 0, vertex_buffer->size / (sizeof(float) * 3));
   glBindVertexArray(0);

--- a/libz11/render_block_state.c
+++ b/libz11/render_block_state.c
@@ -4,6 +4,8 @@
 struct z_render_block_state {
   struct z_gl_vertex_buffer* vertex_buffer; /** nullable */
   struct wl_listener vertex_buffer_destroy_listener;
+  struct z_gl_shader_program* shader_program;
+  struct wl_listener shader_program_destroy_listener;
   enum z11_gl_topology topology;
 };
 
@@ -18,6 +20,17 @@ static void z_render_block_state_vertex_buffer_destroy_signal_handler(struct wl_
   render_block_state->vertex_buffer = NULL;
 }
 
+static void z_render_block_state_shader_program_destroy_signal_handler(struct wl_listener* listener,
+                                                                       void* data)
+{
+  UNUSED(data);
+  struct z_render_block_state* render_block_state;
+
+  render_block_state = wl_container_of(listener, render_block_state, vertex_buffer_destroy_listener);
+
+  render_block_state->shader_program = NULL;
+}
+
 struct z_render_block_state* z_render_block_state_create()
 {
   struct z_render_block_state* state;
@@ -25,8 +38,14 @@ struct z_render_block_state* z_render_block_state_create()
   state = zalloc(sizeof *state);
   if (state == NULL) goto fail;
 
+  state->vertex_buffer = NULL;
   wl_list_init(&state->vertex_buffer_destroy_listener.link);
   state->vertex_buffer_destroy_listener.notify = z_render_block_state_vertex_buffer_destroy_signal_handler;
+
+  state->shader_program = NULL;
+  wl_list_init(&state->shader_program_destroy_listener.link);
+  state->shader_program_destroy_listener.notify = z_render_block_state_shader_program_destroy_signal_handler;
+
   state->topology = Z11_GL_TOPOLOGY_LINES;
 
   return state;
@@ -41,6 +60,9 @@ void z_render_block_state_destroy(struct z_render_block_state* state)
   free(state);
 }
 
+/**
+ * set state->vertex_buffer NULL when client destroyed the vertex_buffer
+ */
 void z_render_block_state_attach_vertex_buffer(struct z_render_block_state* state,
                                                struct z_gl_vertex_buffer* vertex_buffer)
 {
@@ -56,6 +78,26 @@ void z_render_block_state_attach_vertex_buffer(struct z_render_block_state* stat
 struct z_gl_vertex_buffer* z_render_block_state_get_vertex_buffer(struct z_render_block_state* state)
 {
   return state->vertex_buffer;
+}
+
+/**
+ * set state->shader_program NULL when client destroyed the shader_program
+ */
+void z_render_block_state_attach_shader_program(struct z_render_block_state* state,
+                                                struct z_gl_shader_program* shader_program)
+{
+  wl_list_remove(&state->shader_program_destroy_listener.link);
+  z_gl_shader_program_add_destroy_signal_handler(shader_program, &state->shader_program_destroy_listener);
+
+  state->shader_program = shader_program;
+}
+
+/**
+ * @return nullable
+ */
+struct z_gl_shader_program* z_render_block_state_get_shader_program(struct z_render_block_state* state)
+{
+  return state->shader_program;
 }
 
 enum z11_gl_topology z_render_block_state_get_topology(struct z_render_block_state* state)

--- a/protocol/z11.xml
+++ b/protocol/z11.xml
@@ -23,6 +23,11 @@
       <arg name="vertex_buffer" type="object" interface="z11_gl_vertex_buffer"/>
     </request>
 
+    <request name="attach_shader_program">
+      <description summary="attach shader program to the render block">TBD</description>
+      <arg name="shader_program" type="object" interface="z11_gl_shader_program"/>
+    </request>
+
     <request name="set_topology">
       <description summary="set topology mode to render 3D object">TBD</description>
       <arg name="topology" type="uint" enum="z11_gl.topology"/>
@@ -37,8 +42,15 @@
     <description summary="Graphic library api">TBD</description>
 
     <request name="create_vertex_buffer">
-      <description summary="Create a vertex buffer">TBD</description>
+      <description summary="create a vertex buffer">TBD</description>
       <arg name="id" type="new_id" interface="z11_gl_vertex_buffer" summary="the new vertex buffer"/>
+    </request>
+
+    <request name="create_shader_program">
+      <description summary="create a OpenGL Shader Language program">TBD</description>
+      <arg name="id" type="new_id" interface="z11_gl_shader_program" summary="the new GLSL program"/>
+      <arg name="vertex_shader_source" type="string"/>
+      <arg name="fragment_shader_source" type="string"/>
     </request>
 
     <enum name="topology">
@@ -63,5 +75,19 @@
       <arg name="size" type="int" summary="specifies the size in bytes of the buffer's new data store"/>
       <arg name="raw_buffer" type="object" interface="wl_raw_buffer" allow-null="true" summary="nullable"/>
     </request>
+  </interface>
+
+  <interface name="z11_gl_shader_program" version="1">
+    <description summary="OpenGL Shader Language program">
+      Contains vertex shader and fragmane shader.
+    </description>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete vertex buffer">TBD</description>
+    </request>
+
+    <enum name="error">
+      <entry name="compilation_error" value="0"/>
+    </enum>
   </interface>
 </protocol>


### PR DESCRIPTION
クライアント側でShaderを書けるようにした。
なので色をclient側で自由に決められるようになった。

現状shaderに情報を渡す部分はハードコートになってしまっていて、clientはvertex bufferの形式やshaderのUniform変数の名前とかに関して自由に決められないけど、その部分は次以降のPRでやります。

[![](http://img.youtube.com/vi/uuhaC-9Jm4g/hqdefault.jpg)](https://youtu.be/uuhaC-9Jm4g)