### PR TITLE
week ref

### DIFF
--- a/libz11/gl_shader_program.c
+++ b/libz11/gl_shader_program.c
@@ -1,5 +1,4 @@
 #include <GL/glew.h>
-#include <stdio.h>
 #include <wayland-server.h>
 
 #include "internal.h"
@@ -21,9 +20,7 @@ static void z_gl_shader_program_handle_destroy(struct wl_resource* resource)
 static void z_gl_shader_program_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
 {
   UNUSED(client);
-  struct z_gl_shader_program* shader_program = wl_resource_get_user_data(resource);
-
-  z_gl_shader_program_destroy(shader_program);
+  wl_resource_destroy(resource);
 }
 
 static const struct z11_gl_shader_program_interface z_gl_shader_program_interface = {
@@ -128,10 +125,9 @@ void z_gl_shader_program_destroy(struct z_gl_shader_program* shader_program)
   free(shader_program);
 }
 
-void z_gl_shader_program_add_destroy_signal_handler(struct z_gl_shader_program* shader_program,
-                                                    struct wl_listener* listener)
+struct wl_signal* z_gl_shader_program_get_destroy_signal(struct z_gl_shader_program* shader_program)
 {
-  wl_signal_add(&shader_program->destroy_signal, listener);
+  return &shader_program->destroy_signal;
 }
 
 GLuint z_gl_shader_program_get_id(struct z_gl_shader_program* shader_program) { return shader_program->id; }

--- a/libz11/gl_texture_2d.c
+++ b/libz11/gl_texture_2d.c
@@ -20,9 +20,7 @@ static void z_gl_texture_2d_handle_destroy(struct wl_resource* resource)
 static void z_gl_texture_2d_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
 {
   UNUSED(client);
-  struct z_gl_texture_2d* texture = wl_resource_get_user_data(resource);
-
-  z_gl_texture_2d_destroy(texture);
+  wl_resource_destroy(resource);
 }
 
 static void z_gl_texture_2d_protocol_set_image(struct wl_client* client, struct wl_resource* resource,
@@ -90,9 +88,9 @@ static void z_gl_texture_2d_destroy(struct z_gl_texture_2d* texture)
   free(texture);
 }
 
-void z_gl_texture_2d_add_destroy_signal_handler(struct z_gl_texture_2d* texture, struct wl_listener* listener)
+struct wl_signal* z_gl_texture_2d_get_destroy_signal(struct z_gl_texture_2d* texture)
 {
-  wl_signal_add(&texture->destroy_signal, listener);
+  return &texture->destroy_signal;
 }
 
 GLuint z_gl_texture_2d_get_id(struct z_gl_texture_2d* texture) { return texture->id; }

--- a/libz11/gl_vertex_buffer.c
+++ b/libz11/gl_vertex_buffer.c
@@ -15,9 +15,7 @@ static void z_gl_vertex_buffer_handle_destroy(struct wl_resource *resource)
 static void z_gl_vertex_buffer_protocol_destroy(struct wl_client *client, struct wl_resource *resource)
 {
   UNUSED(client);
-  struct z_gl_vertex_buffer *vertex_buffer = wl_resource_get_user_data(resource);
-
-  z_gl_vertex_buffer_destroy(vertex_buffer);
+  wl_resource_destroy(resource);
 }
 
 static void z_gl_vertex_buffer_protocol_allocate(struct wl_client *client, struct wl_resource *resource,

--- a/libz11/internal.h
+++ b/libz11/internal.h
@@ -16,6 +16,24 @@ extern "C" {
 /* helper function */
 inline void* zalloc(size_t size) { return calloc(1, size); }
 
+/* util */
+struct z_week_ref;
+
+typedef void (*z_week_ref_destroy_func_t)(struct z_week_ref* ref);
+
+struct z_week_ref {
+  void* data;  // NULLABLE
+  struct wl_listener destroy_listener;
+  z_week_ref_destroy_func_t destroy_func;
+};
+
+void z_week_ref_init(struct z_week_ref* week_ref);
+
+void z_week_ref_destroy(struct z_week_ref* ref);
+
+void z_week_ref_set_data(struct z_week_ref* ref, void* data, struct wl_signal* destroy_signal,
+                         z_week_ref_destroy_func_t on_destroy);
+
 /* z_compositor */
 
 void z_compositor_append_render_block(struct z_compositor* compositor, struct z_render_block* render_block);
@@ -36,8 +54,7 @@ struct z_gl_texture_2d;
 
 struct z_gl_texture_2d* z_gl_texture_2d_create(struct wl_client* client, uint32_t id);
 
-void z_gl_texture_2d_add_destroy_signal_handler(struct z_gl_texture_2d* texture,
-                                                struct wl_listener* listener);
+struct wl_signal* z_gl_texture_2d_get_destroy_signal(struct z_gl_texture_2d* texture);
 
 GLuint z_gl_texture_2d_get_id(struct z_gl_texture_2d* texture);
 
@@ -49,8 +66,7 @@ struct z_gl_shader_program* z_gl_shader_program_create(struct wl_client* client,
                                                        const char* vertex_shader_source,
                                                        const char* fragment_shader_source);
 
-void z_gl_shader_program_add_destroy_signal_handler(struct z_gl_shader_program* shader_program,
-                                                    struct wl_listener* listener);
+struct wl_signal* z_gl_shader_program_get_destroy_signal(struct z_gl_shader_program* shader_program);
 
 GLuint z_gl_shader_program_get_id(struct z_gl_shader_program* shader_program);
 

--- a/libz11/meson.build
+++ b/libz11/meson.build
@@ -11,6 +11,7 @@ srcs_libz11 = files([
   'gl_vertex_buffer.c',
   'render_block.c',
   'render_block_state.c',
+  'util.c',
 ]) + [
   z11_protocol_c,
   z11_server_protocol_h,

--- a/libz11/render_block.c
+++ b/libz11/render_block.c
@@ -24,9 +24,7 @@ static void z_render_block_handle_destroy(struct wl_resource* resource)
 static void z_render_block_protocol_destroy(struct wl_client* client, struct wl_resource* resource)
 {
   UNUSED(client);
-  struct z_render_block* render_block = wl_resource_get_user_data(resource);
-
-  z_render_block_destroy(render_block);
+  wl_resource_destroy(resource);
 }
 
 static void z_render_block_protocol_attach_vertex_buffer(struct wl_client* client,

--- a/libz11/util.c
+++ b/libz11/util.c
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <wayland-server.h>
+
+#include "internal.h"
+
+static void z_week_pointer_handle_destroy_signal_handler(struct wl_listener* listener, void* data)
+{
+  UNUSED(data);
+  struct z_week_ref* ref;
+
+  ref = wl_container_of(listener, ref, destroy_listener);
+  if (ref->destroy_func) ref->destroy_func(ref->data);
+
+  wl_list_remove(&ref->destroy_listener.link);
+  wl_list_init(&ref->destroy_listener.link);
+  ref->data = NULL;
+  ref->destroy_func = NULL;
+}
+
+void z_week_ref_init(struct z_week_ref* ref)
+{
+  wl_list_init(&ref->destroy_listener.link);
+  ref->destroy_listener.notify = z_week_pointer_handle_destroy_signal_handler;
+  ref->data = NULL;
+  ref->destroy_func = NULL;
+}
+
+void z_week_ref_destroy(struct z_week_ref* ref) { wl_list_remove(&ref->destroy_listener.link); }
+
+void z_week_ref_set_data(struct z_week_ref* ref, void* data, struct wl_signal* destroy_signal,
+                         z_week_ref_destroy_func_t on_destroy)
+{
+  wl_list_remove(&ref->destroy_listener.link);
+  wl_signal_add(destroy_signal, &ref->destroy_listener);
+  ref->data = data;
+  ref->destroy_func = on_destroy;
+}


### PR DESCRIPTION
例えばrender_block_stateにvertex_bufferを割り当てるとき、vertex_bufferはクライアントによっていつ何時destroyされるかわからないので、render_block_stateは知らない間に自分が持ってるvertex_bufferへのpointerが解放されていて使えなくなっている可能性がある。他にもclientが削除されたとき、どの順番でwaylandオブジェクトのデストラクタが呼ばれるかわからないなどの理由から、あるWaylndオブジェクトが他のWaylandオブジェクトの所有者になる(生き死にの管理をする)ことはできない。

ただしwaylandオブジェクト間のrelationは必要なので、現状では例えばrender_block_stateにvertex_bufferを割り当てる時は、ざっくり言って、
- vertex_bufferがデストラクタでdestroy signalを発行できるようにする。(waylandにそんな感じのことをする機能がある)
- render_block_stateにvertex_bufferを割り当てる時にvertex_bufferのdestroy signalをlistenしておく。
- render_block_stateのvertex_bufferメンバに代入する。

destroy signalのハンドラでは
- render_block_stateのvetex_bufferをNULLにする。

的なことをして、vertex_bufferが解放されると勝手に値がNULLになるようにしてたんだけど、こんな感じの所有権のない弱い結びつきで、いつNULLになるかわからないみたいなものは今後も多いと思うので、それを扱うwee_refを作った。

それとは別に *_protocol_destroy() 関数にがっつりバグがあったのでなおした。