### PR TITLE
Change default display name to "z11-0"

### DIFF
--- a/zazen/z_server.cc
+++ b/zazen/z_server.cc
@@ -5,7 +5,7 @@
 
 bool ZServer::Init()
 {
-  const char* socket;
+  const char* socket = "z11-0";
   struct zazen_opengl* gl;
 
   display_ = wl_display_create();
@@ -22,8 +22,7 @@ bool ZServer::Init()
 
   wl_display_init_shm(display_);
 
-  socket = wl_display_add_socket_auto(display_);
-  if (socket == NULL) return false;
+  if (wl_display_add_socket(display_, socket) != 0) return false;
 
   return true;
 }


### PR DESCRIPTION
題名の通り。

今までは
$XDG_RUNTIME_DIR/wayland-0
がデフォルトで使われるunix socketだったけど
$XDG_RUNTIME_DIR/z11-0
にした。ZWaylandと一緒に起動する時の設定を簡単にするため。