### PR TITLE
Refactor render item

### DIFF
--- a/libzazen/keyboard.h
+++ b/libzazen/keyboard.h
@@ -1,7 +1,7 @@
 #ifndef LIBZAZEN_KEYBOARD_H
 #define LIBZAZEN_KEYBOARD_H
 
-#include "opengl_render_item.h"
+#include <wayland-server.h>
 
 struct zazen_keyboard_grab;
 struct zazen_keyboard_grab_interface {
@@ -22,8 +22,6 @@ struct zazen_keyboard {
   struct zazen_seat *seat;
   struct zazen_keyboard_grab *grab;
   struct zazen_keyboard_grab default_grab;
-
-  struct zazen_opengl_render_item *render_item;
 };
 
 struct zazen_keyboard *zazen_keyboard_create(struct zazen_seat *seat);

--- a/libzazen/opengl_render_component.h
+++ b/libzazen/opengl_render_component.h
@@ -10,8 +10,7 @@
 struct zazen_opengl_render_component {
   struct wl_resource* resource;
   struct zazen_opengl_render_component_manager* manager;
-
-  bool state_changed;
+  struct zazen_opengl_render_item* render_item;
 
   struct wl_listener virtual_object_destroy_signal_listener;
   struct wl_listener virtual_object_commit_signal_listener;
@@ -27,11 +26,6 @@ struct zazen_opengl_render_component {
   _Nullable struct zazen_opengl_texture_2d* texture_2d;
   struct wl_listener texture_2d_state_change_listener;
   struct wl_listener texture_2d_destroy_listener;
-
-  struct wl_array vertex_input_attributes;
-  enum z11_opengl_topology topology;
-
-  struct zazen_opengl_render_component_back_state back_state;
 };
 
 struct zazen_opengl_render_component* zazen_opengl_render_component_create(

--- a/libzazen/opengl_render_component_back_state.c
+++ b/libzazen/opengl_render_component_back_state.c
@@ -161,6 +161,15 @@ void zazen_opengl_render_component_back_state_generate_vertex_array(
   glBindVertexArray(0);
 }
 
+void zazen_opengl_render_component_back_state_destroy(
+    struct zazen_opengl_render_component_back_state* back_state)
+{
+  zazen_opengl_render_component_back_state_delete_texture_2d(back_state);
+  zazen_opengl_render_component_back_state_delete_shader_program(back_state);
+  zazen_opengl_render_component_back_state_delete_vertex_buffer(back_state);
+  zazen_opengl_render_component_back_state_delete_vertex_array(back_state);
+}
+
 static GLuint get_size_from_attribute_format(
     enum z11_opengl_vertex_input_attribute_format format)
 {

--- a/libzazen/opengl_render_component_back_state.h
+++ b/libzazen/opengl_render_component_back_state.h
@@ -12,33 +12,45 @@ struct zazen_opengl_render_component_back_state_vertex_input_attribute {
   uint32_t offset;
 };
 
+// texture
 void zazen_opengl_render_component_back_state_delete_texture_2d(
     struct zazen_opengl_render_component_back_state* back_state);
+
 void zazen_opengl_render_component_back_state_generate_texture_2d(
     struct zazen_opengl_render_component_back_state* back_state,
     enum z11_opengl_texture_2d_format format, int32_t width, int32_t height,
     void* data, int32_t buffer_size);
 
+// shader
 void zazen_opengl_render_component_back_state_delete_shader_program(
     struct zazen_opengl_render_component_back_state* back_state);
+
 bool zazen_opengl_render_component_back_state_generate_shader_program(
     struct zazen_opengl_render_component_back_state* back_state,
     const char* vertex_shader_source, const char* fragment_shader_source);
 
+// vertex buffer
 void zazen_opengl_render_component_back_state_delete_vertex_buffer(
     struct zazen_opengl_render_component_back_state* back_state);
+
 void zazen_opengl_render_component_back_state_generate_vertex_buffer(
     struct zazen_opengl_render_component_back_state* back_state,
     int32_t buffer_size, void* data, uint32_t stride);
 
+// topology mode
 void zazen_opengl_render_component_back_state_set_topology_mode(
     struct zazen_opengl_render_component_back_state* back_state,
     enum z11_opengl_topology topology);
 
+// vertex_array
 void zazen_opengl_render_component_back_state_delete_vertex_array(
     struct zazen_opengl_render_component_back_state* back_state);
+
 void zazen_opengl_render_component_back_state_generate_vertex_array(
     struct zazen_opengl_render_component_back_state* back_state,
     struct wl_array* vertex_input_attributes);
+
+void zazen_opengl_render_component_back_state_destroy(
+    struct zazen_opengl_render_component_back_state* back_state);
 
 #endif  // LIBZAZEN_OPENGL_RENDER_COMPONENT_BACK_STATE_H

--- a/libzazen/opengl_render_item.c
+++ b/libzazen/opengl_render_item.c
@@ -5,6 +5,34 @@
 #include "opengl_render_component_back_state.h"
 #include "util.h"
 
+struct zazen_opengl_render_item {
+  struct zazen_opengl_render_component_manager* manager;
+
+  void* vertex_buffer_data;
+  int32_t vertex_buffer_size;
+  uint32_t vertex_buffer_stride;
+  bool vertex_buffer_changed;
+
+  void* texture_2d_data;
+  enum z11_opengl_texture_2d_format texture_format;
+  int32_t texture_width;
+  int32_t texture_height;
+  int32_t texture_buffer_size;
+  bool texture_changed;
+
+  const char* vertex_shader_source;
+  const char* fragment_shader_source;
+  bool shader_changed;
+
+  struct wl_array vertex_input_attributes;
+  bool input_attributes_changed;
+
+  enum z11_opengl_topology topology;
+  bool topology_changed;
+
+  struct zazen_opengl_render_component_back_state back_state;
+};
+
 struct zazen_opengl_render_item* zazen_opengl_render_item_create(
     struct zazen_opengl_render_component_manager* manager)
 {
@@ -17,13 +45,12 @@ struct zazen_opengl_render_item* zazen_opengl_render_item_create(
 
   render_item->manager = manager;
 
-  render_item->state_changed = true;
-
-  render_item->vertex_buffer_data = NULL;
-  render_item->texture_2d_data = NULL;
-
-  render_item->vertex_shader_source = NULL;
-  render_item->fragment_shader_source = NULL;
+  render_item->vertex_buffer_changed = false;
+  render_item->texture_changed = false;
+  render_item->shader_changed = false;
+  render_item->input_attributes_changed = false;
+  render_item->topology_changed = true;
+  render_item->topology = Z11_OPENGL_TOPOLOGY_LINES;  // default value
 
   wl_array_init(&render_item->vertex_input_attributes);
 
@@ -40,85 +67,208 @@ void zazen_opengl_render_item_destroy(
 {
   wl_array_release(&render_item->vertex_input_attributes);
   wl_list_remove(&render_item->back_state.link);
-  // TODO: clean up back state
-  free(render_item->vertex_buffer_data);
-  free(render_item->texture_2d_data);
+  zazen_opengl_render_component_back_state_destroy(&render_item->back_state);
   free(render_item);
 }
 
-static void commit_texture_2d(struct zazen_opengl_render_item* render_item);
-static bool commit_shader_program(struct zazen_opengl_render_item* render_item);
-static void commit_vertex_buffer(struct zazen_opengl_render_item* render_item);
-static void commit_vertex_array(struct zazen_opengl_render_item* render_item);
+void zazen_opengl_render_item_set_vertex_buffer(
+    struct zazen_opengl_render_item* render_item, void* vertex_buffer_data,
+    int32_t vertex_buffer_size, uint32_t vertex_buffer_stride)
+{
+  render_item->vertex_buffer_data = vertex_buffer_data;
+  render_item->vertex_buffer_size = vertex_buffer_size;
+  render_item->vertex_buffer_stride = vertex_buffer_stride;
+  render_item->vertex_buffer_changed = true;
+}
 
-void zazen_opengl_render_item_commit(
+void zazen_opengl_render_item_unset_vertex_buffer(
+    struct zazen_opengl_render_item* render_item)
+{
+  render_item->vertex_buffer_data = NULL;
+  render_item->vertex_buffer_changed = true;
+}
+
+void zazen_opengl_render_item_set_texture_2d(
+    struct zazen_opengl_render_item* render_item, void* texture_data,
+    enum z11_opengl_texture_2d_format format, int32_t width, int32_t height,
+    int32_t buffer_size)
+{
+  render_item->texture_2d_data = texture_data;
+  render_item->texture_format = format;
+  render_item->texture_width = width;
+  render_item->texture_height = height;
+  render_item->texture_buffer_size = buffer_size;
+  render_item->texture_changed = true;
+}
+
+void zazen_opengl_render_item_unset_texture_2d(
+    struct zazen_opengl_render_item* render_item)
+{
+  render_item->texture_2d_data = NULL;
+  render_item->texture_changed = true;
+}
+
+void zazen_opengl_render_item_set_shader(
+    struct zazen_opengl_render_item* render_item,
+    const char* vertex_shader_source, const char* fragment_shader_source)
+{
+  render_item->vertex_shader_source = vertex_shader_source;
+  render_item->fragment_shader_source = fragment_shader_source;
+  render_item->shader_changed = true;
+}
+
+void zazen_opengl_render_item_unset_shader(
+    struct zazen_opengl_render_item* render_item)
+{
+  render_item->vertex_shader_source = NULL;
+  render_item->fragment_shader_source = NULL;
+  render_item->shader_changed = true;
+}
+
+void zazen_opengl_render_item_append_vertex_input_attribute(
+    struct zazen_opengl_render_item* render_item, uint32_t location,
+    enum z11_opengl_vertex_input_attribute_format format, uint32_t offset)
+{
+  struct zazen_opengl_render_component_back_state_vertex_input_attribute*
+      input_attribute;
+  input_attribute = wl_array_add(&render_item->vertex_input_attributes,
+                                 sizeof *input_attribute);
+  input_attribute->location = location;
+  input_attribute->format = format;
+  input_attribute->offset = offset;
+  render_item->input_attributes_changed = true;
+}
+
+void zazen_opengl_render_item_clear_vertex_input_attribute(
+    struct zazen_opengl_render_item* render_item)
+{
+  wl_array_release(&render_item->vertex_input_attributes);
+  wl_array_init(&render_item->vertex_input_attributes);
+  render_item->input_attributes_changed = true;
+}
+
+void zazen_opengl_render_item_set_topology(
+    struct zazen_opengl_render_item* render_item,
+    enum z11_opengl_topology topology)
+{
+  render_item->topology = topology;
+  render_item->topology_changed = true;
+}
+
+static bool commit_texture_2d(struct zazen_opengl_render_item* render_item);
+static bool commit_shader_program(struct zazen_opengl_render_item* render_item);
+static bool commit_vertex_buffer(struct zazen_opengl_render_item* render_item);
+static bool commit_topology(struct zazen_opengl_render_item* render_item);
+static bool commit_vertex_array(struct zazen_opengl_render_item* render_item);
+
+bool zazen_opengl_render_item_commit(
     struct zazen_opengl_render_item* render_item)
 {
   wl_list_remove(&render_item->back_state.link);
   wl_list_init(&render_item->back_state.link);
 
   commit_texture_2d(render_item);
-  if (commit_shader_program(render_item) == false) {
-    // TODO: Error handle
-    return;
+
+  if (commit_shader_program(render_item) == false ||
+      commit_vertex_buffer(render_item) == false ||
+      commit_topology(render_item) == false ||
+      commit_vertex_array(render_item) == false) {
+    render_item->texture_changed = false;
+    render_item->shader_changed = false;
+    render_item->vertex_buffer_changed = false;
+    render_item->topology_changed = false;
+    render_item->input_attributes_changed = false;
+    return false;
   }
-  commit_vertex_buffer(render_item);
-
-  zazen_opengl_render_component_back_state_set_topology_mode(
-      &render_item->back_state, render_item->topology);
-
-  commit_vertex_array(render_item);
 
   wl_list_insert(&render_item->manager->render_component_back_state_list,
                  &render_item->back_state.link);
+
+  render_item->texture_changed = false;
+  render_item->shader_changed = false;
+  render_item->vertex_buffer_changed = false;
+  render_item->topology_changed = false;
+  render_item->input_attributes_changed = false;
+  return true;
 }
 
-static void commit_texture_2d(struct zazen_opengl_render_item* render_item)
+static bool commit_texture_2d(struct zazen_opengl_render_item* render_item)
 {
+  if (render_item->texture_changed == false)
+    return render_item->back_state.texture_2d_id != 0;
+
   zazen_opengl_render_component_back_state_delete_texture_2d(
       &render_item->back_state);
 
-  if (render_item->texture_2d_data == NULL) return;
+  if (render_item->texture_2d_data == NULL) return false;
 
-  // TODO: Enable to create texture 2d with render item
+  zazen_opengl_render_component_back_state_generate_texture_2d(
+      &render_item->back_state, render_item->texture_format,
+      render_item->texture_width, render_item->texture_height,
+      render_item->texture_2d_data, render_item->texture_buffer_size);
+
+  return true;
 }
 
 static bool commit_shader_program(struct zazen_opengl_render_item* render_item)
 {
+  if (render_item->shader_changed == false)
+    return render_item->back_state.shader_program_id != 0;
+
   zazen_opengl_render_component_back_state_delete_shader_program(
       &render_item->back_state);
 
   if (render_item->vertex_shader_source == NULL ||
       render_item->fragment_shader_source == NULL)
-    return true;
+    return false;
 
   return zazen_opengl_render_component_back_state_generate_shader_program(
       &render_item->back_state, render_item->vertex_shader_source,
       render_item->fragment_shader_source);
+
+  return true;
 }
 
-static void commit_vertex_buffer(struct zazen_opengl_render_item* render_item)
+static bool commit_vertex_buffer(struct zazen_opengl_render_item* render_item)
 {
+  if (render_item->vertex_buffer_changed == false)
+    return render_item->back_state.vertex_buffer_id != 0;
+
   zazen_opengl_render_component_back_state_delete_vertex_buffer(
       &render_item->back_state);
 
-  if (render_item->vertex_buffer_data == NULL) return;
+  if (render_item->vertex_buffer_data == NULL) return false;
 
   zazen_opengl_render_component_back_state_generate_vertex_buffer(
       &render_item->back_state, render_item->vertex_buffer_size,
       render_item->vertex_buffer_data, render_item->vertex_buffer_stride);
+
+  return true;
 }
 
-static void commit_vertex_array(struct zazen_opengl_render_item* render_item)
+static bool commit_topology(struct zazen_opengl_render_item* render_item)
 {
+  if (render_item->topology_changed == false) return true;
+
+  zazen_opengl_render_component_back_state_set_topology_mode(
+      &render_item->back_state, render_item->topology);
+
+  return true;
+}
+
+static bool commit_vertex_array(struct zazen_opengl_render_item* render_item)
+{
+  if (render_item->vertex_buffer_changed == false &&
+      render_item->input_attributes_changed == false)
+    return render_item->back_state.vertex_array_id != 0;
+
   zazen_opengl_render_component_back_state_delete_vertex_array(
       &render_item->back_state);
 
-  if (render_item->back_state.vertex_buffer_id == 0 ||
-      render_item->back_state.shader_program_id == 0) {
-    return;
-  }
+  if (render_item->vertex_buffer_data == NULL) return false;
 
   zazen_opengl_render_component_back_state_generate_vertex_array(
       &render_item->back_state, &render_item->vertex_input_attributes);
+
+  return true;
 }

--- a/libzazen/opengl_render_item.h
+++ b/libzazen/opengl_render_item.h
@@ -7,25 +7,7 @@
 #include "opengl_render_component_back_state.h"
 #include "opengl_render_component_manager.h"
 
-struct zazen_opengl_render_item {
-  struct zazen_opengl_render_component_manager* manager;
-  bool state_changed;
-
-  void* vertex_buffer_data;
-  void* texture_2d_data;
-
-  char* vertex_shader_source;
-  char* fragment_shader_source;
-
-  int32_t vertex_buffer_size;
-  uint32_t vertex_buffer_stride;
-
-  struct wl_array vertex_input_attributes;
-
-  enum z11_opengl_topology topology;
-
-  struct zazen_opengl_render_component_back_state back_state;
-};
+struct zazen_opengl_render_item;
 
 struct zazen_opengl_render_item* zazen_opengl_render_item_create(
     struct zazen_opengl_render_component_manager* manager);
@@ -33,7 +15,43 @@ struct zazen_opengl_render_item* zazen_opengl_render_item_create(
 void zazen_opengl_render_item_destroy(
     struct zazen_opengl_render_item* render_item);
 
-void zazen_opengl_render_item_commit(
+// vertex_buffer_data must be alive until the next commit
+void zazen_opengl_render_item_set_vertex_buffer(
+    struct zazen_opengl_render_item* render_item, void* vertex_buffer_data,
+    int32_t vertex_buffer_size, uint32_t vertex_buffer_stride);
+
+void zazen_opengl_render_item_unset_vertex_buffer(
+    struct zazen_opengl_render_item* render_item);
+
+// texture_data must be alive until the next commit
+void zazen_opengl_render_item_set_texture_2d(
+    struct zazen_opengl_render_item* render_item, void* texture_data,
+    enum z11_opengl_texture_2d_format format, int32_t width, int32_t height,
+    int32_t buffer_size);
+
+void zazen_opengl_render_item_unset_texture_2d(
+    struct zazen_opengl_render_item* render_item);
+
+// shader sources must be alive until the next commit
+void zazen_opengl_render_item_set_shader(
+    struct zazen_opengl_render_item* render_item,
+    const char* vertex_shader_source, const char* fragment_shader_source);
+
+void zazen_opengl_render_item_unset_shader(
+    struct zazen_opengl_render_item* render_item);
+
+void zazen_opengl_render_item_append_vertex_input_attribute(
+    struct zazen_opengl_render_item* render_item, uint32_t location,
+    enum z11_opengl_vertex_input_attribute_format format, uint32_t offset);
+
+void zazen_opengl_render_item_clear_vertex_input_attribute(
+    struct zazen_opengl_render_item* render_item);
+
+void zazen_opengl_render_item_set_topology(
+    struct zazen_opengl_render_item* render_item,
+    enum z11_opengl_topology topology);
+
+bool zazen_opengl_render_item_commit(
     struct zazen_opengl_render_item* render_item);
 
 #endif  // LIBZAZEN_OPENGL_RENDER_ITEM_H

--- a/libzazen/pointer.h
+++ b/libzazen/pointer.h
@@ -2,6 +2,11 @@
 #define LIBZAZEN_POINTER_H
 
 #include "opengl_render_item.h"
+#include "types.h"
+
+typedef struct {
+  Point begin, end;
+} Ray;
 
 enum zazen_pointer_motion_mask {
   ZAZEN_POINTER_MOTION_ABS = 1 << 0,
@@ -51,6 +56,7 @@ struct zazen_pointer {
   struct zazen_pointer_grab default_grab;
 
   struct zazen_opengl_render_item *render_item;
+  Ray ray;
 };
 
 void zazen_pointer_notify_motion(struct zazen_pointer *pointer,

--- a/libzazen/types.h
+++ b/libzazen/types.h
@@ -1,0 +1,8 @@
+#ifndef ZAZEN_TYPES_H
+#define ZAZEN_TYPES_H
+
+typedef struct {
+  float x, y, z;
+} Point;
+
+#endif  //  ZAZEN_TYPES_H


### PR DESCRIPTION
Render Itemをリファクタリングした。

変更のあったものだけ、OpenGLを使ってGPUのメモリ上に再配置し直したり、
必要なリソースがない(textureはなくてもいいけど、shaderは必ず必要)場合はback_stateをrender_component_managerのリストから外して、描画されないようにする、またその場合はcommit時にfalseを返す。など実装した。

また、render_componentもrender_itemを使って実装し直すことで、だいぶスッキリした。行数も50減った。

#46 とコンフリクトが全くなかったので、普通にmainにPR出します。

@shierote 
#45 ←これはこのPRの上にrebaseしてもらって、リファクタしたrender itemを使ってもらうのがいい気がする。
