### PR TITLE
Model Matrix

### DIFF
--- a/clients/meson.build
+++ b/clients/meson.build
@@ -31,6 +31,7 @@ executable(
   simple_box_source_files,
   install : true,
   dependencies : dependencies,
+  include_directories : public_inc,
 )
 
 executable(
@@ -38,4 +39,5 @@ executable(
   png_viewer_source_files,
   install : true,
   dependencies : dependencies,
+  include_directories : public_inc,
 )

--- a/clients/png_viewer.cc
+++ b/clients/png_viewer.cc
@@ -9,7 +9,7 @@
 
 const char *vertex_shader =
     "#version 410\n"
-    "uniform mat4 matrix;\n"
+    "uniform mat4 mvp;\n"
     "layout(location = 0) in vec4 position;\n"
     "layout(location = 1) in vec2 v2UVcoordsIn;\n"
     "layout(location = 2) in vec3 v3NormalIn;\n"
@@ -17,7 +17,7 @@ const char *vertex_shader =
     "void main()\n"
     "{\n"
     "  v2UVcoords = v2UVcoordsIn;\n"
-    "  gl_Position = matrix * position;\n"
+    "  gl_Position = mvp * position;\n"
     "}\n";
 
 const char *fragment_shader =
@@ -219,10 +219,10 @@ struct wl_callback *PngViewer::MainLoop()
   float c = (image_width / 2 * cos(theta_) + depth_ / 2 * sin(theta_));
   float d = (image_width / 2 * sin(theta_) - depth_ / 2 * cos(theta_));
 
-  Vertex A = {{a, +y, b + 50}, {0, 0}};
-  Vertex B = {{a, -y, b + 50}, {0, 1}};
-  Vertex C = {{c, -y, d + 50}, {1, 1}};
-  Vertex D = {{c, +y, d + 50}, {1, 0}};
+  Vertex A = {{a, +y, b}, {0, 0}};
+  Vertex B = {{a, -y, b}, {0, 1}};
+  Vertex C = {{c, -y, d}, {1, 1}};
+  Vertex D = {{c, +y, d}, {1, 0}};
 
   panel_data_->triangles[0].vertices[0] = A;
   panel_data_->triangles[0].vertices[1] = B;

--- a/clients/png_viewer.cc
+++ b/clients/png_viewer.cc
@@ -122,9 +122,10 @@ bool PngViewer::Init()
   {
     struct wl_shm_pool *pool =
         wl_shm_create_pool(zwindow_->shm(), fd, sizeof(Panel) + texture_size);
-    panel_raw_buffer_ = wl_shm_pool_create_raw_buffer(pool, 0, sizeof(Panel));
+    panel_raw_buffer_ =
+        wl_zext_shm_pool_create_raw_buffer(pool, 0, sizeof(Panel));
     texture_raw_buffer_ =
-        wl_shm_pool_create_raw_buffer(pool, sizeof(Panel), texture_size);
+        wl_zext_shm_pool_create_raw_buffer(pool, sizeof(Panel), texture_size);
     wl_shm_pool_destroy(pool);
   }
 

--- a/clients/png_viewer.h
+++ b/clients/png_viewer.h
@@ -1,6 +1,7 @@
 #ifndef Z11_CLIENT_PNG_VIEWER_H
 #define Z11_CLIENT_PNG_VIEWER_H
 
+#include <wl_zext_client.h>
 #include <z11-client-protocol.h>
 
 #include "png_loader.h"
@@ -60,8 +61,8 @@ class PngViewer
   struct z11_virtual_object *virtual_object_;
   Panel *panel_data_;
   ColorBGRA *texture_data_;
-  wl_raw_buffer *panel_raw_buffer_;
-  wl_raw_buffer *texture_raw_buffer_;
+  struct wl_zext_raw_buffer *panel_raw_buffer_;
+  struct wl_zext_raw_buffer *texture_raw_buffer_;
   struct z11_opengl_texture_2d *texture_;
   struct z11_opengl_vertex_buffer *panel_vertex_buffer_;
   struct z11_opengl_shader_program *shader_program_;

--- a/clients/simple_box.cc
+++ b/clients/simple_box.cc
@@ -77,7 +77,7 @@ bool SimpleBox::Init()
   {
     struct wl_shm_pool *pool;
     pool = wl_shm_create_pool(zwindow_->shm(), fd, sizeof(Box));
-    box_raw_buffer_ = wl_shm_pool_create_raw_buffer(pool, 0, sizeof(Box));
+    box_raw_buffer_ = wl_zext_shm_pool_create_raw_buffer(pool, 0, sizeof(Box));
     wl_shm_pool_destroy(pool);
   }
 

--- a/clients/simple_box.cc
+++ b/clients/simple_box.cc
@@ -9,7 +9,7 @@
 
 const char *vertex_shader =
     "#version 410\n"
-    "uniform mat4 matrix;\n"
+    "uniform mat4 mvp;\n"
     "layout(location = 0) in vec4 position;\n"
     "layout(location = 1) in vec2 v2UVcoordsIn;\n"
     "layout(location = 2) in vec3 v3NormalIn;\n"
@@ -17,7 +17,7 @@ const char *vertex_shader =
     "void main()\n"
     "{\n"
     "  v2UVcoords = v2UVcoordsIn;\n"
-    "  gl_Position = matrix * position;\n"
+    "  gl_Position = mvp * position;\n"
     "}\n";
 
 const char *fragment_shader =
@@ -151,14 +151,14 @@ struct wl_callback *SimpleBox::MainLoop()
   float c = (size * cos(theta_) + size * sin(theta_));
   float d = (size * sin(theta_) - size * cos(theta_));
 
-  Point A = {-a, +y, -b + 50};
-  Point B = {+c, +y, +d + 50};
-  Point C = {+a, +y, +b + 50};
-  Point D = {-c, +y, -d + 50};
-  Point E = {-a, -y, -b + 50};
-  Point F = {+c, -y, +d + 50};
-  Point G = {+a, -y, +b + 50};
-  Point H = {-c, -y, -d + 50};
+  Point A = {-a, +y, -b};
+  Point B = {+c, +y, +d};
+  Point C = {+a, +y, +b};
+  Point D = {-c, +y, -d};
+  Point E = {-a, -y, -b};
+  Point F = {+c, -y, +d};
+  Point G = {+a, -y, +b};
+  Point H = {-c, -y, -d};
   box_data_->edges[0].start = A;
   box_data_->edges[0].end = B;
   box_data_->edges[1].start = B;

--- a/clients/simple_box.h
+++ b/clients/simple_box.h
@@ -1,6 +1,7 @@
 #ifndef Z11_CLIENT_SIMPLE_BOX_H
 #define Z11_CLIENT_SIMPLE_BOX_H
 
+#include <wl_zext_client.h>
 #include <z11-client-protocol.h>
 
 #include "z_window.h"
@@ -34,7 +35,7 @@ class SimpleBox
   ZWindow *zwindow_;
   struct z11_virtual_object *virtual_object_;
   Box *box_data_;
-  wl_raw_buffer *box_raw_buffer_;
+  struct wl_zext_raw_buffer *box_raw_buffer_;
   struct z11_opengl_vertex_buffer *box_vertex_buffer_;
   struct z11_opengl_shader_program *shader_program_;
   struct z11_opengl_render_component *render_component_;

--- a/clients/stl_viewer.c
+++ b/clients/stl_viewer.c
@@ -104,22 +104,21 @@ static char *create_vertex_shader_with_model_matrix(int dx, int dy, int dz)
   sprintf(shader,
           (  //
               "#version 410\n"
-              "uniform mat4 matrix;\n"
-              "uniform mat4 model;\n"
+              "uniform mat4 mvp;\n"
               "layout(location = 0) in vec4 position;\n"
               "layout(location = 1) in vec2 v2UVcoordsIn;\n"
               "layout(location = 2) in vec3 v3NormalIn;\n"
               "out vec2 v2UVcoords;\n"
               "void main()\n"
               "{\n"
-              "  mat4 model = mat4(\n"
+              "  mat4 trans = mat4(\n"
               "  1, 0, 0, 0,\n"
               "  0, 0, 1, 0,\n"
               "  0, 1, 0, 0,\n"
               "  %d, %d, %d, 1\n"
               "  );\n"
               "  v2UVcoords = v2UVcoordsIn;\n"
-              "  gl_Position = matrix * model * position;\n"
+              "  gl_Position = mvp * trans * position;\n"
               "}\n"  //
               ),
           dx, dy, dz);

--- a/include/libzazen.h
+++ b/include/libzazen.h
@@ -26,6 +26,7 @@ struct zazen_opengl_render_component_back_state {
   int32_t vertex_buffer_size;
   uint32_t vertex_stride;
   GLenum topology_mode;
+  float model_matrix[16];
 };
 
 /* zazen_opengl_render_component_manager */

--- a/include/libzazen.h
+++ b/include/libzazen.h
@@ -53,7 +53,9 @@ struct zazen_seat* zazen_seat_create(
 /* zazen_shell */
 struct zazen_shell;
 
-struct zazen_shell* zazen_shell_create(struct wl_display* display);
+struct zazen_shell* zazen_shell_create(
+    struct wl_display* display,
+    struct zazen_opengl_render_component_manager* manager);
 
 #ifdef __cplusplus
 }

--- a/include/wl_zext_client.h
+++ b/include/wl_zext_client.h
@@ -1,0 +1,16 @@
+#ifndef WL_ZEXT_CLIENT_H
+#define WL_ZEXT_CLIENT_H
+
+#include <wayland-client.h>
+
+#define wl_zext_raw_buffer wl_buffer
+
+inline struct wl_zext_raw_buffer *wl_zext_shm_pool_create_raw_buffer(
+    wl_shm_pool *wl_shm_pool, int32_t offset, int32_t size)
+{
+  return wl_shm_pool_create_buffer(wl_shm_pool, offset, size, 1, size, 0);
+}
+
+// TODO: implement other protocols
+
+#endif  //  WL_ZEXT_CLIENT_H

--- a/include/wl_zext_server.h
+++ b/include/wl_zext_server.h
@@ -1,0 +1,20 @@
+#ifndef WL_ZEXT_SERVER_H
+#define WL_ZEXT_SERVER_H
+
+#include <wayland-server-core.h>
+
+#define wl_zext_shm_raw_buffer wl_shm_buffer
+#define wl_zext_shm_raw_buffer_get wl_shm_buffer_get
+#define wl_zext_shm_raw_buffer_begin_access wl_shm_buffer_begin_access
+#define wl_zext_shm_raw_buffer_end_access wl_shm_buffer_end_access
+#define wl_zext_shm_raw_buffer_get_data wl_shm_buffer_get_data
+#define wl_zext_shm_raw_buffer_ref_pool wl_shm_buffer_ref_pool
+
+int32_t wl_zext_shm_raw_buffer_get_size(struct wl_zext_shm_raw_buffer *buffer)
+{
+  int32_t stride = wl_shm_buffer_get_stride(buffer);
+  int32_t height = wl_shm_buffer_get_height(buffer);
+  return stride * height;
+}
+
+#endif  //  WL_ZEXT_SERVER_H

--- a/libzazen/cuboid_window.c
+++ b/libzazen/cuboid_window.c
@@ -3,7 +3,14 @@
 #include <wayland-server.h>
 #include <z11-server-protocol.h>
 
+#include "opengl_render_component_manager.h"
 #include "util.h"
+#include "virtual_object.h"
+
+static const char* fragment_shader;
+static const char* vertex_shader;
+static void zazen_cuboid_window_update_vertex_buffer(
+    struct zazen_cuboid_window* cuboid_window);
 
 static void zazen_cuboid_window_destroy(
     struct zazen_cuboid_window* cuboid_window);
@@ -31,6 +38,12 @@ static void zazen_cuboid_window_protocol_request_window_size(
   cuboid_window->depth = wl_fixed_to_double(depth);
 
   z11_cuboid_window_send_configure(resource, width, height, depth);
+
+  zazen_cuboid_window_update_vertex_buffer(cuboid_window);
+  zazen_opengl_render_item_set_vertex_buffer(
+      cuboid_window->render_item, cuboid_window->vertex_buffer[0],
+      sizeof cuboid_window->vertex_buffer, sizeof(vec3));
+  zazen_opengl_render_item_commit(cuboid_window->render_item);
 }
 
 static const struct z11_cuboid_window_interface zazen_cuboid_window_interface =
@@ -38,8 +51,23 @@ static const struct z11_cuboid_window_interface zazen_cuboid_window_interface =
         .request_window_size = zazen_cuboid_window_protocol_request_window_size,
 };
 
-struct zazen_cuboid_window* zazen_cuboid_window_create(struct wl_client* client,
-                                                       uint32_t id)
+static void virtual_object_model_matrix_change_handler(
+    struct wl_listener* listener, void* data)
+{
+  struct zazen_virtual_object* virtual_object = data;
+  struct zazen_cuboid_window* cuboid_window;
+
+  cuboid_window = wl_container_of(listener, cuboid_window,
+                                  virtual_object_model_matrix_change_listener);
+
+  zazen_opengl_render_item_set_model_matrix(cuboid_window->render_item,
+                                            virtual_object->model_matrix);
+}
+
+struct zazen_cuboid_window* zazen_cuboid_window_create(
+    struct wl_client* client, uint32_t id,
+    struct zazen_virtual_object* virtual_object,
+    struct zazen_opengl_render_component_manager* manager)
 {
   struct zazen_cuboid_window* cuboid_window;
   struct wl_resource* resource;
@@ -50,17 +78,41 @@ struct zazen_cuboid_window* zazen_cuboid_window_create(struct wl_client* client,
     goto out;
   }
 
+  cuboid_window->render_item = zazen_opengl_render_item_create(manager);
+  if (cuboid_window->render_item == NULL) {
+    wl_client_post_no_memory(client);
+    goto out_cuboid_window;
+  }
+
   resource = wl_resource_create(client, &z11_cuboid_window_interface, 1, id);
   if (resource == NULL) {
     wl_client_post_no_memory(client);
-    goto out_cuboid_window;
+    goto out_render_item;
   }
 
   wl_resource_set_implementation(resource, &zazen_cuboid_window_interface,
                                  cuboid_window,
                                  zazen_cuboid_window_handle_destroy);
 
+  cuboid_window->virtual_object_model_matrix_change_listener.notify =
+      virtual_object_model_matrix_change_handler;
+  wl_signal_add(&virtual_object->model_matrix_change_signal,
+                &cuboid_window->virtual_object_model_matrix_change_listener);
+
+  zazen_opengl_render_item_set_shader(cuboid_window->render_item, vertex_shader,
+                                      fragment_shader);
+  zazen_opengl_render_item_set_topology(cuboid_window->render_item,
+                                        Z11_OPENGL_TOPOLOGY_LINES);
+  zazen_opengl_render_item_append_vertex_input_attribute(
+      cuboid_window->render_item, 0,
+      Z11_OPENGL_VERTEX_INPUT_ATTRIBUTE_FORMAT_FLOAT_VECTOR3, 0);
+  zazen_opengl_render_item_set_model_matrix(cuboid_window->render_item,
+                                            virtual_object->model_matrix);
+
   return cuboid_window;
+
+out_render_item:
+  zazen_opengl_render_item_destroy(cuboid_window->render_item);
 
 out_cuboid_window:
   free(cuboid_window);
@@ -72,5 +124,117 @@ out:
 static void zazen_cuboid_window_destroy(
     struct zazen_cuboid_window* cuboid_window)
 {
+  zazen_opengl_render_item_destroy(cuboid_window->render_item);
   free(cuboid_window);
+}
+
+static const char* vertex_shader =
+    "#version 410\n"
+    "uniform mat4 mvp;\n"
+    "layout(location = 0) in vec4 position;\n"
+    "layout(location = 1) in vec2 v2UVcoordsIn;\n"
+    "layout(location = 2) in vec3 v3NormalIn;\n"
+    "out vec2 v2UVcoords;\n"
+    "void main()\n"
+    "{\n"
+    "  v2UVcoords = v2UVcoordsIn;\n"
+    "  gl_Position = mvp * position;\n"
+    "}\n";
+
+static const char* fragment_shader =
+    "#version 410 core\n"
+    "in vec2 v2UVcoords;\n"
+    "out vec4 outputColor;\n"
+    "void main()\n"
+    "{\n"
+    "  outputColor = vec4(0.0, 0.0, 0.543, 1.0);\n"
+    "}\n";
+
+static void zazen_cuboid_window_update_vertex_buffer(
+    struct zazen_cuboid_window* cuboid_window)
+{
+  float w = cuboid_window->width / 2;
+  float h = cuboid_window->height / 2;
+  float d = cuboid_window->depth / 2;
+  float l = 1.5;
+  vec3 A = {-w, -h, -d};
+  vec3 B = {+w, -h, -d};
+  vec3 C = {+w, +h, -d};
+  vec3 D = {-w, +h, -d};
+  vec3 E = {-w, -h, +d};
+  vec3 F = {+w, -h, +d};
+  vec3 G = {+w, +h, +d};
+  vec3 H = {-w, +h, +d};
+  vec3 AB = {-w / l, -h, -d};
+  vec3 BA = {+w / l, -h, -d};
+  vec3 BC = {+w, -h / l, -d};
+  vec3 CB = {+w, +h / l, -d};
+  vec3 CD = {+w / l, +h, -d};
+  vec3 DC = {-w / l, +h, -d};
+  vec3 DA = {-w, +h / l, -d};
+  vec3 AD = {-w, -h / l, -d};
+  vec3 EF = {-w / l, -h, +d};
+  vec3 FE = {+w / l, -h, +d};
+  vec3 FG = {+w, -h / l, +d};
+  vec3 GF = {+w, +h / l, +d};
+  vec3 GH = {+w / l, +h, +d};
+  vec3 HG = {-w / l, +h, +d};
+  vec3 HE = {-w, +h / l, +d};
+  vec3 EH = {-w, -h / l, +d};
+  vec3 AE = {-w, -h, -d / l};
+  vec3 EA = {-w, -h, +d / l};
+  vec3 BF = {+w, -h, -d / l};
+  vec3 FB = {+w, -h, +d / l};
+  vec3 CG = {+w, +h, -d / l};
+  vec3 GC = {+w, +h, +d / l};
+  vec3 DH = {-w, +h, -d / l};
+  vec3 HD = {-w, +h, +d / l};
+  glm_vec3_copy(A, cuboid_window->vertex_buffer[0]);
+  glm_vec3_copy(AB, cuboid_window->vertex_buffer[1]);
+  glm_vec3_copy(BA, cuboid_window->vertex_buffer[2]);
+  glm_vec3_copy(B, cuboid_window->vertex_buffer[3]);
+  glm_vec3_copy(B, cuboid_window->vertex_buffer[4]);
+  glm_vec3_copy(BC, cuboid_window->vertex_buffer[5]);
+  glm_vec3_copy(CB, cuboid_window->vertex_buffer[6]);
+  glm_vec3_copy(C, cuboid_window->vertex_buffer[7]);
+  glm_vec3_copy(C, cuboid_window->vertex_buffer[8]);
+  glm_vec3_copy(CD, cuboid_window->vertex_buffer[9]);
+  glm_vec3_copy(DC, cuboid_window->vertex_buffer[10]);
+  glm_vec3_copy(D, cuboid_window->vertex_buffer[11]);
+  glm_vec3_copy(D, cuboid_window->vertex_buffer[12]);
+  glm_vec3_copy(DA, cuboid_window->vertex_buffer[13]);
+  glm_vec3_copy(AD, cuboid_window->vertex_buffer[14]);
+  glm_vec3_copy(A, cuboid_window->vertex_buffer[15]);
+  glm_vec3_copy(E, cuboid_window->vertex_buffer[16]);
+  glm_vec3_copy(EF, cuboid_window->vertex_buffer[17]);
+  glm_vec3_copy(FE, cuboid_window->vertex_buffer[18]);
+  glm_vec3_copy(F, cuboid_window->vertex_buffer[19]);
+  glm_vec3_copy(F, cuboid_window->vertex_buffer[20]);
+  glm_vec3_copy(FG, cuboid_window->vertex_buffer[21]);
+  glm_vec3_copy(GF, cuboid_window->vertex_buffer[22]);
+  glm_vec3_copy(G, cuboid_window->vertex_buffer[23]);
+  glm_vec3_copy(G, cuboid_window->vertex_buffer[24]);
+  glm_vec3_copy(GH, cuboid_window->vertex_buffer[25]);
+  glm_vec3_copy(HG, cuboid_window->vertex_buffer[26]);
+  glm_vec3_copy(H, cuboid_window->vertex_buffer[27]);
+  glm_vec3_copy(H, cuboid_window->vertex_buffer[28]);
+  glm_vec3_copy(HE, cuboid_window->vertex_buffer[29]);
+  glm_vec3_copy(EH, cuboid_window->vertex_buffer[30]);
+  glm_vec3_copy(E, cuboid_window->vertex_buffer[31]);
+  glm_vec3_copy(A, cuboid_window->vertex_buffer[32]);
+  glm_vec3_copy(AE, cuboid_window->vertex_buffer[33]);
+  glm_vec3_copy(EA, cuboid_window->vertex_buffer[34]);
+  glm_vec3_copy(E, cuboid_window->vertex_buffer[35]);
+  glm_vec3_copy(B, cuboid_window->vertex_buffer[36]);
+  glm_vec3_copy(BF, cuboid_window->vertex_buffer[37]);
+  glm_vec3_copy(FB, cuboid_window->vertex_buffer[38]);
+  glm_vec3_copy(F, cuboid_window->vertex_buffer[39]);
+  glm_vec3_copy(C, cuboid_window->vertex_buffer[40]);
+  glm_vec3_copy(CG, cuboid_window->vertex_buffer[41]);
+  glm_vec3_copy(GC, cuboid_window->vertex_buffer[42]);
+  glm_vec3_copy(G, cuboid_window->vertex_buffer[43]);
+  glm_vec3_copy(D, cuboid_window->vertex_buffer[44]);
+  glm_vec3_copy(DH, cuboid_window->vertex_buffer[45]);
+  glm_vec3_copy(HD, cuboid_window->vertex_buffer[46]);
+  glm_vec3_copy(H, cuboid_window->vertex_buffer[47]);
 }

--- a/libzazen/cuboid_window.c
+++ b/libzazen/cuboid_window.c
@@ -238,3 +238,28 @@ static void zazen_cuboid_window_update_vertex_buffer(
   glm_vec3_copy(HD, cuboid_window->vertex_buffer[46]);
   glm_vec3_copy(H, cuboid_window->vertex_buffer[47]);
 }
+
+//                                         /z+
+//                                        /
+//                    H.--------.HG  GH.---------.G
+//                    /|                /       /|
+//                   / |        ^y     /       / |
+//                HD.  |        |     /     GC.  |
+//                     .HE      |    /           .GF
+//              DH.             |   /       .CG
+//               /     .EH      |  /       /     .FG
+//              /      |        | /       /      |
+//            D.---------.DC CD.---------.C      |
+//  -----------|--------------- / -------|------------>x
+//             |      E.-------/-.EF FE.-|-------.F
+//             |      /       / |        |      /
+//           DA.     /       /  |      CB.     /
+//                  .EA     /   |             .FB
+//           AD.           /    |      BC.
+//             |  .AE     /     |        |  .BF
+//             | /       /      |        | /
+//             |/               |        |/
+//             .---------.     .---------.
+//            A          AB   BA|        B
+//                              |
+//                              |

--- a/libzazen/cuboid_window.h
+++ b/libzazen/cuboid_window.h
@@ -1,15 +1,25 @@
 #ifndef LIBZAZEN_CUBOID_WINDOW
 #define LIBZAZEN_CUBOID_WINDOW
 
+#include <cglm/cglm.h>
 #include <wayland-server.h>
 
+#include "opengl_render_component_manager.h"
+#include "opengl_render_item.h"
+#include "virtual_object.h"
+
 struct zazen_cuboid_window {
-  uint32_t width;
-  uint32_t height;
-  uint32_t depth;
+  float width;
+  float height;
+  float depth;
+  struct zazen_opengl_render_item* render_item;
+  vec3 vertex_buffer[48];
+  struct wl_listener virtual_object_model_matrix_change_listener;
 };
 
-struct zazen_cuboid_window* zazen_cuboid_window_create(struct wl_client* client,
-                                                       uint32_t id);
+struct zazen_cuboid_window* zazen_cuboid_window_create(
+    struct wl_client* client, uint32_t id,
+    struct zazen_virtual_object* virtual_object,
+    struct zazen_opengl_render_component_manager* manager);
 
 #endif  //  LIBZAZEN_CUBOID_WINDOW

--- a/libzazen/opengl_render_component.c
+++ b/libzazen/opengl_render_component.c
@@ -2,6 +2,7 @@
 
 #include <stdio.h>
 #include <wayland-server.h>
+#include <wl_zext_server.h>
 
 #include "opengl_render_component_back_state.h"
 #include "opengl_render_component_manager.h"
@@ -45,14 +46,14 @@ static void vertex_buffer_state_change_listener(struct wl_listener* listener,
   if (render_component->vertex_buffer == NULL ||
       render_component->vertex_buffer->raw_buffer_resource == NULL) {
   } else {
-    struct wl_shm_raw_buffer* shm_raw_buffer;
+    struct wl_zext_shm_raw_buffer* shm_raw_buffer;
     void* data;
     int32_t buffer_size;
 
-    shm_raw_buffer = wl_shm_raw_buffer_get(
+    shm_raw_buffer = wl_zext_shm_raw_buffer_get(
         render_component->vertex_buffer->raw_buffer_resource);
-    data = wl_shm_raw_buffer_get_data(shm_raw_buffer);
-    buffer_size = wl_shm_raw_buffer_get_size(shm_raw_buffer);
+    data = wl_zext_shm_raw_buffer_get_data(shm_raw_buffer);
+    buffer_size = wl_zext_shm_raw_buffer_get_size(shm_raw_buffer);
     zazen_opengl_render_item_set_vertex_buffer(
         render_component->render_item, data, buffer_size,
         render_component->vertex_buffer->stride);
@@ -102,14 +103,14 @@ static void zazen_opengl_render_component_protocol_attach_vertex_buffer(
   if (render_component->vertex_buffer->raw_buffer_resource == NULL) {
     zazen_opengl_render_item_unset_vertex_buffer(render_component->render_item);
   } else {
-    struct wl_shm_raw_buffer* shm_raw_buffer;
+    struct wl_zext_shm_raw_buffer* shm_raw_buffer;
     void* data;
     int32_t buffer_size;
 
-    shm_raw_buffer = wl_shm_raw_buffer_get(
+    shm_raw_buffer = wl_zext_shm_raw_buffer_get(
         render_component->vertex_buffer->raw_buffer_resource);
-    data = wl_shm_raw_buffer_get_data(shm_raw_buffer);
-    buffer_size = wl_shm_raw_buffer_get_size(shm_raw_buffer);
+    data = wl_zext_shm_raw_buffer_get_data(shm_raw_buffer);
+    buffer_size = wl_zext_shm_raw_buffer_get_size(shm_raw_buffer);
     zazen_opengl_render_item_set_vertex_buffer(
         render_component->render_item, data, buffer_size,
         render_component->vertex_buffer->stride);
@@ -194,13 +195,13 @@ static void texture_2d_state_change_listener(struct wl_listener* listener,
   } else {
     struct zazen_opengl_texture_2d_state* state =
         render_component->texture_2d->state;
-    struct wl_shm_raw_buffer* shm_raw_buffer;
+    struct wl_zext_shm_raw_buffer* shm_raw_buffer;
     void* data;
     int32_t buffer_size;
 
-    shm_raw_buffer = wl_shm_raw_buffer_get(state->raw_buffer_resource);
-    data = wl_shm_raw_buffer_get_data(shm_raw_buffer);
-    buffer_size = wl_shm_raw_buffer_get_size(shm_raw_buffer);
+    shm_raw_buffer = wl_zext_shm_raw_buffer_get(state->raw_buffer_resource);
+    data = wl_zext_shm_raw_buffer_get_data(shm_raw_buffer);
+    buffer_size = wl_zext_shm_raw_buffer_get_size(shm_raw_buffer);
     zazen_opengl_render_item_set_texture_2d(render_component->render_item, data,
                                             state->format, state->width,
                                             state->height, buffer_size);
@@ -251,13 +252,13 @@ static void zazen_opengl_render_component_protocol_attach_texture_2d(
   } else {
     struct zazen_opengl_texture_2d_state* state =
         render_component->texture_2d->state;
-    struct wl_shm_raw_buffer* shm_raw_buffer;
+    struct wl_zext_shm_raw_buffer* shm_raw_buffer;
     void* data;
     int32_t buffer_size;
 
-    shm_raw_buffer = wl_shm_raw_buffer_get(state->raw_buffer_resource);
-    data = wl_shm_raw_buffer_get_data(shm_raw_buffer);
-    buffer_size = wl_shm_raw_buffer_get_size(shm_raw_buffer);
+    shm_raw_buffer = wl_zext_shm_raw_buffer_get(state->raw_buffer_resource);
+    data = wl_zext_shm_raw_buffer_get_data(shm_raw_buffer);
+    buffer_size = wl_zext_shm_raw_buffer_get_size(shm_raw_buffer);
     zazen_opengl_render_item_set_texture_2d(render_component->render_item, data,
                                             state->format, state->width,
                                             state->height, buffer_size);

--- a/libzazen/opengl_render_component.c
+++ b/libzazen/opengl_render_component.c
@@ -347,6 +347,19 @@ static void virtual_object_commit_signal_handler(struct wl_listener* listener,
   zazen_opengl_render_item_commit(render_component->render_item);
 }
 
+static void virtual_object_model_matrix_change_handler(
+    struct wl_listener* listener, void* data)
+{
+  struct zazen_virtual_object* virtual_object = data;
+  struct zazen_opengl_render_component* render_component;
+
+  render_component = wl_container_of(
+      listener, render_component, virtual_object_model_matrix_change_listener);
+
+  zazen_opengl_render_item_set_model_matrix(render_component->render_item,
+                                            virtual_object->model_matrix);
+}
+
 struct zazen_opengl_render_component* zazen_opengl_render_component_create(
     struct wl_client* client, uint32_t id,
     struct zazen_opengl_render_component_manager* manager,
@@ -393,6 +406,11 @@ struct zazen_opengl_render_component* zazen_opengl_render_component_create(
   wl_signal_add(&virtual_object->commit_signal,
                 &render_component->virtual_object_commit_signal_listener);
 
+  render_component->virtual_object_model_matrix_change_listener.notify =
+      virtual_object_model_matrix_change_handler;
+  wl_signal_add(&virtual_object->model_matrix_change_signal,
+                &render_component->virtual_object_model_matrix_change_listener);
+
   render_component->vertex_buffer = NULL;
   render_component->vertex_buffer_state_change_listener.notify =
       vertex_buffer_state_change_listener;
@@ -416,6 +434,9 @@ struct zazen_opengl_render_component* zazen_opengl_render_component_create(
   render_component->texture_2d_destroy_listener.notify =
       texture_2d_destroy_listener;
   wl_list_init(&render_component->texture_2d_destroy_listener.link);
+
+  zazen_opengl_render_item_set_model_matrix(render_component->render_item,
+                                            virtual_object->model_matrix);
 
   return render_component;
 

--- a/libzazen/opengl_render_component.h
+++ b/libzazen/opengl_render_component.h
@@ -14,6 +14,7 @@ struct zazen_opengl_render_component {
 
   struct wl_listener virtual_object_destroy_signal_listener;
   struct wl_listener virtual_object_commit_signal_listener;
+  struct wl_listener virtual_object_model_matrix_change_listener;
 
   _Nullable struct zazen_opengl_vertex_buffer* vertex_buffer;
   struct wl_listener vertex_buffer_state_change_listener;

--- a/libzazen/opengl_render_component_back_state.c
+++ b/libzazen/opengl_render_component_back_state.c
@@ -2,6 +2,8 @@
 #include "opengl_render_component_back_state.h"
 
 #include <GL/glew.h>
+#include <cglm/cglm.h>
+#include <string.h>
 #include <wayland-util.h>
 
 #include "util.h"
@@ -125,6 +127,13 @@ void zazen_opengl_render_component_back_state_set_topology_mode(
     enum z11_opengl_topology topology)
 {
   back_state->topology_mode = get_topology_mode(topology);
+}
+
+void zazen_opengl_render_component_back_state_set_model_view(
+    struct zazen_opengl_render_component_back_state* back_state,
+    mat4 model_matrix)
+{
+  memcpy(back_state->model_matrix, model_matrix, sizeof(float) * 16);
 }
 
 void zazen_opengl_render_component_back_state_delete_vertex_array(

--- a/libzazen/opengl_render_component_back_state.c
+++ b/libzazen/opengl_render_component_back_state.c
@@ -129,7 +129,7 @@ void zazen_opengl_render_component_back_state_set_topology_mode(
   back_state->topology_mode = get_topology_mode(topology);
 }
 
-void zazen_opengl_render_component_back_state_set_model_view(
+void zazen_opengl_render_component_back_state_set_model_matrix(
     struct zazen_opengl_render_component_back_state* back_state,
     mat4 model_matrix)
 {

--- a/libzazen/opengl_render_component_back_state.h
+++ b/libzazen/opengl_render_component_back_state.h
@@ -55,7 +55,7 @@ void zazen_opengl_render_component_back_state_destroy(
     struct zazen_opengl_render_component_back_state* back_state);
 
 // model_matrix
-void zazen_opengl_render_component_back_state_set_model_view(
+void zazen_opengl_render_component_back_state_set_model_matrix(
     struct zazen_opengl_render_component_back_state* back_state,
     mat4 model_matrix);
 

--- a/libzazen/opengl_render_component_back_state.h
+++ b/libzazen/opengl_render_component_back_state.h
@@ -2,6 +2,7 @@
 #define LIBZAZEN_OPENGL_RENDER_COMPONENT_BACK_STATE_H
 
 #include <GL/glew.h>
+#include <cglm/cglm.h>
 #include <libzazen.h>
 
 #include "z11-opengl-server-protocol.h"
@@ -52,5 +53,10 @@ void zazen_opengl_render_component_back_state_generate_vertex_array(
 
 void zazen_opengl_render_component_back_state_destroy(
     struct zazen_opengl_render_component_back_state* back_state);
+
+// model_matrix
+void zazen_opengl_render_component_back_state_set_model_view(
+    struct zazen_opengl_render_component_back_state* back_state,
+    mat4 model_matrix);
 
 #endif  // LIBZAZEN_OPENGL_RENDER_COMPONENT_BACK_STATE_H

--- a/libzazen/opengl_render_item.c
+++ b/libzazen/opengl_render_item.c
@@ -271,7 +271,7 @@ static bool commit_model_matrix(struct zazen_opengl_render_item* render_item)
 {
   if (render_item->topology_changed == false) return true;
 
-  zazen_opengl_render_component_back_state_set_model_view(
+  zazen_opengl_render_component_back_state_set_model_matrix(
       &render_item->back_state, render_item->model_matrix);
 
   return true;

--- a/libzazen/opengl_render_item.h
+++ b/libzazen/opengl_render_item.h
@@ -51,6 +51,9 @@ void zazen_opengl_render_item_set_topology(
     struct zazen_opengl_render_item* render_item,
     enum z11_opengl_topology topology);
 
+void zazen_opengl_render_item_set_model_matrix(
+    struct zazen_opengl_render_item* render_item, mat4 model_matrix);
+
 bool zazen_opengl_render_item_commit(
     struct zazen_opengl_render_item* render_item);
 

--- a/libzazen/ray.c
+++ b/libzazen/ray.c
@@ -141,7 +141,7 @@ void zazen_ray_destroy(struct zazen_ray* ray)
 
 static const char* vertex_shader =
     "#version 410\n"
-    "uniform mat4 matrix;\n"
+    "uniform mat4 mvp;\n"
     "layout(location = 0) in vec4 position;\n"
     "layout(location = 1) in vec2 v2UVcoordsIn;\n"
     "layout(location = 2) in vec3 v3NormalIn;\n"
@@ -149,7 +149,7 @@ static const char* vertex_shader =
     "void main()\n"
     "{\n"
     "  v2UVcoords = v2UVcoordsIn;\n"
-    "  gl_Position = matrix * position;\n"
+    "  gl_Position = mvp * position;\n"
     "}\n";
 
 static const char* fragment_shader =

--- a/libzazen/shell.h
+++ b/libzazen/shell.h
@@ -1,9 +1,13 @@
 #ifndef LIBZAZEN_SHELL_H
 #define LIBZAZEN_SHELL_H
 
+#include "opengl_render_component_manager.h"
+
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
-struct zazen_shell {};
+struct zazen_shell {
+  struct zazen_opengl_render_component_manager *render_component_manager;
+};
 #pragma GCC diagnostic pop
 
 #endif  //  LIBZAZEN_SHELL_H

--- a/libzazen/virtual_object.c
+++ b/libzazen/virtual_object.c
@@ -117,14 +117,15 @@ struct zazen_virtual_object *zazen_virtual_object_create(
 
   wl_list_init(&virtual_object->pending_frame_callback_list);
   wl_list_init(&virtual_object->frame_callback_list);
+  wl_signal_init(&virtual_object->model_matrix_change_signal);
 
-  mat4 z_30 = {
-      {1, 0, 0, 0},
-      {0, 1, 0, 0},
-      {0, 0, 1, 0},   //
-      {0, 0, 30, 1},  //
-  };
-  glm_mat4_copy(z_30, virtual_object->model_matrix);
+  glm_mat4_copy(GLM_MAT4_IDENTITY, virtual_object->model_matrix);
+
+  // FIXME: remove this code after implementing the feature to move the cuboid
+  // window
+  glm_translate_x(virtual_object->model_matrix, rand() / (RAND_MAX / 128) - 64);
+  glm_translate_y(virtual_object->model_matrix, rand() / (RAND_MAX / 128) - 64);
+  glm_translate_z(virtual_object->model_matrix, rand() / (RAND_MAX / 64) + 40);
 
   return virtual_object;
 
@@ -141,4 +142,11 @@ static void zazen_virtual_object_destroy(
   wl_signal_emit(&virtual_object->destroy_signal, virtual_object);
   wl_list_remove(&virtual_object->component_frame_signal_listener.link);
   free(virtual_object);
+}
+
+void zazen_virtual_object_update_model_matrix(
+    struct zazen_virtual_object *virtual_object, mat4 model_matrix)
+{
+  glm_mat4_copy(model_matrix, virtual_object->model_matrix);
+  wl_signal_emit(&virtual_object->model_matrix_change_signal, virtual_object);
 }

--- a/libzazen/virtual_object.h
+++ b/libzazen/virtual_object.h
@@ -14,9 +14,13 @@ struct zazen_virtual_object {
   struct wl_list pending_frame_callback_list;
   struct wl_list frame_callback_list;
   mat4 model_matrix;
+  struct wl_signal model_matrix_change_signal;
 };
 
 struct zazen_virtual_object *zazen_virtual_object_create(
     struct wl_client *client, uint32_t id, struct zazen_compositor *compositor);
+
+void zazen_virtual_object_update_model_matrix(
+    struct zazen_virtual_object *virtual_object, mat4 model_matrix);
 
 #endif  //  LIBZAZEN_VIRTUAL_OBJECT_H

--- a/protocol/z11_opengl.xml
+++ b/protocol/z11_opengl.xml
@@ -110,7 +110,7 @@
 
     <request name="attach">
       <description summary="attach buffer">TBD</description>
-      <arg name="raw_buffer" type="object" interface="wl_raw_buffer"/>
+      <arg name="raw_buffer" type="object" interface="wl_buffer"/>
       <arg name="vertex_stride" type="uint"/>
     </request>
   </interface>
@@ -138,7 +138,7 @@
 
     <request name="set_image">
       <description summary="delete texture">TBD</description>
-      <arg name="raw_buffer" type="object" interface="wl_raw_buffer"/>
+      <arg name="raw_buffer" type="object" interface="wl_buffer"/>
       <arg name="format" type="uint" enum="format"/>
       <arg name="width" type="int"/>
       <arg name="height" type="int"/>

--- a/zazen/renderer.cc
+++ b/zazen/renderer.cc
@@ -23,10 +23,12 @@ void Renderer::Render(Eye *eye,
   glEnable(GL_DEPTH_TEST);
   do {
     glUseProgram(render_state->shader_program_id);
-    GLint view_projection_matrix_location =
-        glGetUniformLocation(render_state->shader_program_id, "matrix");
-    glUniformMatrix4fv(view_projection_matrix_location, 1, GL_FALSE,
-                       eye->view_projection().get());
+    Matrix4 model_matrix = Matrix4(render_state->model_matrix);
+    Matrix4 view_projection_matrix = eye->view_projection().get();
+    GLint model_view_projection_matrix_location =
+        glGetUniformLocation(render_state->shader_program_id, "mvp");
+    glUniformMatrix4fv(model_view_projection_matrix_location, 1, GL_FALSE,
+                       (view_projection_matrix * model_matrix).get());
     glBindVertexArray(render_state->vertex_array_id);
     glBindTexture(GL_TEXTURE_2D, render_state->texture_2d_id);
     glDrawArrays(

--- a/zazen/z_server.cc
+++ b/zazen/z_server.cc
@@ -21,7 +21,7 @@ bool ZServer::Init()
       zazen_opengl_render_component_manager_create(display_);
   if (render_component_manager_ == NULL) return false;
 
-  shell_ = zazen_shell_create(display_);
+  shell_ = zazen_shell_create(display_, render_component_manager_);
   if (shell_ == NULL) return false;
 
   wl_display_init_shm(display_);


### PR DESCRIPTION
### https://github.com/gray-armor/z11/pull/52/commits/6f1efd4d3987c143871026f05aefd8fdfb0d2eb9

model matrixをrender_itemおよびrender_component_back_stateに定義した。
render_itemのAPIを叩くことでmodel_matrixを更新できる。

描画の際もmodel view projection matrixをshaderに渡すようにした。

model matrixを更新することでcuboid windowの移動などが実現できる。

### https://github.com/gray-armor/z11/pull/52/commits/ff77ba0700c6d23b058cc4588893da6a597f6aef

#54 の内容。

[![](http://img.youtube.com/vi/CWW3xn0vEJU/hqdefault.jpg)](https://youtu.be/CWW3xn0vEJU)

### https://github.com/gray-armor/z11/pull/52/commits/588b06eb6ba0a3ede84df2909e692410fb282efa

図を足しただけ

### https://github.com/gray-armor/z11/pull/52/commits/3891c44ffb804a50f492bccc93c99dc2494b06a8

#40 の内容

Customのwaylandを使っていると自分のwaylandの環境を汚さなきゃいけないので、試しにzazenを使ってみるか、という気持ちが起こらなくなる気がした。ので、zazen内で適当なラッパーを書いて対応した。