### PR TITLE
Add keyboard

### DIFF
--- a/clients/z_window.cc
+++ b/clients/z_window.cc
@@ -68,13 +68,22 @@ static const struct z11_ray_listener ray_listener = {
     handle_button,
 };
 
+static const struct z11_keyboard_listener keyboard_listener = {};
+// TODO: handle keyboard event;
+
 static void seat_capability(void *data, struct z11_seat *seat,
                             uint32_t capabilities)
 {
   struct z11_ray *ray;
+  struct z11_keyboard *keyboard;
+
   if (capabilities & Z11_SEAT_CAPABILITY_RAY) {
     ray = z11_seat_get_ray(seat);
     z11_ray_add_listener(ray, &ray_listener, data);
+  }
+  if (capabilities & Z11_SEAT_CAPABILITY_KEYBOARD) {
+    keyboard = z11_seat_get_keyboard(seat);
+    z11_keyboard_add_listener(keyboard, &keyboard_listener, data);
   }
 }
 

--- a/libzazen/keyboard.c
+++ b/libzazen/keyboard.c
@@ -2,15 +2,63 @@
 
 #include "util.h"
 
+static void grab_keyboard_key(struct zazen_keyboard_grab* grab,
+                              const struct timespec* time, uint32_t key,
+                              uint32_t state)
+{
+  UNUSED(grab);
+  UNUSED(time);
+  UNUSED(key);
+  UNUSED(state);
+  // TODO
+}
+
+static void grab_keyboard_modifiers(struct zazen_keyboard_grab* grab,
+                                    uint32_t serial, uint32_t mods_depressed,
+                                    uint32_t mods_latched, uint32_t mods_locked,
+                                    uint32_t group)
+{
+  UNUSED(grab);
+  UNUSED(serial);
+  UNUSED(mods_depressed);
+  UNUSED(mods_latched);
+  UNUSED(mods_locked);
+  UNUSED(group);
+  // TODO
+}
+
+void grab_keyboard_cancel(struct zazen_keyboard_grab* grab)
+{
+  UNUSED(grab);
+  // TODO
+}
+
+static const struct zazen_keyboard_grab_interface keyboard_grab_interface = {
+    .key = grab_keyboard_key,
+    .modifiers = grab_keyboard_modifiers,
+    .cancel = grab_keyboard_cancel,
+};
+
 struct zazen_keyboard* zazen_keyboard_create(struct zazen_seat* seat)
 {
-  UNUSED(seat);
-  // TODO: create keyboard
-  return NULL;
+  struct zazen_keyboard* keyboard;
+
+  keyboard = zalloc(sizeof *keyboard);
+  if (keyboard == NULL) return NULL;
+
+  keyboard->seat = seat;
+
+  keyboard->grab.interface = &keyboard_grab_interface;
+  keyboard->grab.keyboard = keyboard;
+
+  wl_list_init(&keyboard->keyboard_clients);
+  wl_signal_init(&keyboard->destroy_signal);
+
+  return keyboard;
 }
 
 void zazen_keyboard_destroy(struct zazen_keyboard* keyboard)
 {
-  UNUSED(keyboard);
-  // TODO: destroy keyboard
+  wl_signal_emit(&keyboard->destroy_signal, keyboard);
+  free(keyboard);
 }

--- a/libzazen/keyboard.c
+++ b/libzazen/keyboard.c
@@ -10,7 +10,7 @@ static void grab_keyboard_key(struct zazen_keyboard_grab* grab,
   UNUSED(time);
   UNUSED(key);
   UNUSED(state);
-  // TODO
+  // TODO: send event to client
 }
 
 static void grab_keyboard_modifiers(struct zazen_keyboard_grab* grab,
@@ -24,13 +24,13 @@ static void grab_keyboard_modifiers(struct zazen_keyboard_grab* grab,
   UNUSED(mods_latched);
   UNUSED(mods_locked);
   UNUSED(group);
-  // TODO
+  // TODO: send event to client
 }
 
 void grab_keyboard_cancel(struct zazen_keyboard_grab* grab)
 {
   UNUSED(grab);
-  // TODO
+  // TODO: send event to client
 }
 
 static const struct zazen_keyboard_grab_interface keyboard_grab_interface = {

--- a/libzazen/keyboard.h
+++ b/libzazen/keyboard.h
@@ -20,8 +20,10 @@ struct zazen_keyboard_grab {
 
 struct zazen_keyboard {
   struct zazen_seat *seat;
-  struct zazen_keyboard_grab *grab;
-  struct zazen_keyboard_grab default_grab;
+  struct zazen_keyboard_grab grab;
+
+  struct wl_list keyboard_clients;
+  struct wl_signal destroy_signal;
 };
 
 struct zazen_keyboard *zazen_keyboard_create(struct zazen_seat *seat);

--- a/libzazen/keyboard_client.c
+++ b/libzazen/keyboard_client.c
@@ -84,5 +84,3 @@ static void zazen_keyboard_client_destroy(
   wl_list_remove(&keyboard_client->link);
   free(keyboard_client);
 }
-
-// TODO: wl_list initとかをどういう条件でやらないといけないか？

--- a/libzazen/keyboard_client.c
+++ b/libzazen/keyboard_client.c
@@ -69,6 +69,8 @@ struct zazen_keyboard_client* zazen_keyboard_client_create(
   wl_signal_add(&keyboard->destroy_signal,
                 &keyboard_client->keyboard_destroy_signal_listener);
 
+  wl_list_insert(&keyboard->keyboard_clients, &keyboard_client->link);
+
   return keyboard_client;
 
 out:

--- a/libzazen/keyboard_client.c
+++ b/libzazen/keyboard_client.c
@@ -1,0 +1,88 @@
+#include "keyboard_client.h"
+
+#include <wayland-server.h>
+
+#include "util.h"
+#include "z11-input-server-protocol.h"
+
+static void zazen_keyboard_client_destroy(
+    struct zazen_keyboard_client* keyboard_client);
+
+static void zazen_keyboard_client_handle_destroy(struct wl_resource* resource)
+{
+  struct zazen_keyboard_client* keyboard_client;
+
+  keyboard_client = wl_resource_get_user_data(resource);
+
+  zazen_keyboard_client_destroy(keyboard_client);
+}
+
+static void zazen_keyboard_client_protocol_release(struct wl_client* client,
+                                                   struct wl_resource* resource)
+{
+  UNUSED(client);
+  wl_resource_destroy(resource);
+}
+
+static const struct z11_keyboard_interface zazen_keyboard_interface = {
+    .release = zazen_keyboard_client_protocol_release,
+};
+
+static void keyboard_destroy_signal_handler(struct wl_listener* listener,
+                                            void* data)
+{
+  UNUSED(data);
+  struct zazen_keyboard_client* keyboard_client;
+
+  keyboard_client = wl_container_of(listener, keyboard_client,
+                                    keyboard_destroy_signal_listener);
+
+  wl_resource_destroy(keyboard_client->resource);
+}
+
+struct zazen_keyboard_client* zazen_keyboard_client_create(
+    struct zazen_keyboard* keyboard, struct wl_client* client, uint32_t id)
+{
+  struct zazen_keyboard_client* keyboard_client;
+  struct wl_resource* resource;
+
+  keyboard_client = zalloc(sizeof *keyboard_client);
+  if (keyboard_client == NULL) {
+    wl_client_post_no_memory(client);
+    return NULL;
+  }
+
+  resource = wl_resource_create(client, &z11_keyboard_interface, 1, id);
+  if (resource == NULL) {
+    wl_client_post_no_memory(client);
+    goto out;
+  }
+
+  wl_resource_set_implementation(resource, &zazen_keyboard_interface,
+                                 keyboard_client,
+                                 zazen_keyboard_client_handle_destroy);
+
+  keyboard_client->resource = resource;
+
+  keyboard_client->keyboard_destroy_signal_listener.notify =
+      keyboard_destroy_signal_handler;
+  wl_signal_add(&keyboard->destroy_signal,
+                &keyboard_client->keyboard_destroy_signal_listener);
+
+  return keyboard_client;
+
+out:
+  free(keyboard_client);
+
+  return NULL;
+}
+
+static void zazen_keyboard_client_destroy(
+    struct zazen_keyboard_client* keyboard_client)
+{
+  wl_list_remove(&keyboard_client->keyboard_destroy_signal_listener.link);
+  wl_list_remove(&keyboard_client->link);
+  free(keyboard_client);
+}
+
+// TODO: wl_list initとかをどういう条件でやらないといけないか？

--- a/libzazen/keyboard_client.h
+++ b/libzazen/keyboard_client.h
@@ -1,0 +1,18 @@
+#ifndef LIBZAZEN_KEYBOARD_CLIENT_H
+#define LIBZAZEN_KEYBOARD_CLIENT_H
+
+#include <wayland-server.h>
+
+#include "keyboard.h"
+
+struct zazen_keyboard_client {
+  struct wl_list link;
+  struct wl_resource* resource;
+
+  struct wl_listener keyboard_destroy_signal_listener;
+};
+
+struct zazen_keyboard_client* zazen_keyboard_client_create(
+    struct zazen_keyboard* keyboard, struct wl_client* client, uint32_t id);
+
+#endif  // LIBZAZEN_KEYBOARD_CLIENT_H

--- a/libzazen/lib_input.c
+++ b/libzazen/lib_input.c
@@ -36,7 +36,6 @@ static void handle_device_added(struct zazen_seat *seat,
     if (!zazen_seat_init_keyboard(seat)) {
       zazen_log("Failed to init keyboard\n");
     }
-    return;
   }
 
   if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_POINTER)) {
@@ -49,9 +48,13 @@ static void handle_device_added(struct zazen_seat *seat,
 static void handle_device_removed(struct zazen_seat *seat,
                                   struct libinput_device *device)
 {
-  UNUSED(seat);
-  UNUSED(device);
-  // TODO: handle remove device
+  if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_KEYBOARD)) {
+    zazen_seat_release_keyboard(seat);
+  }
+
+  if (libinput_device_has_capability(device, LIBINPUT_DEVICE_CAP_POINTER)) {
+    zazen_seat_release_ray(seat);
+  }
 }
 
 static int handle_event(int fd, uint32_t mask, void *data)
@@ -80,7 +83,6 @@ static int handle_event(int fd, uint32_t mask, void *data)
       default:
         break;
     }
-    // TODO: Handle remove keyboard, ray;
     libinput_event_destroy(event);
     result = 0;
   }

--- a/libzazen/lib_input.c
+++ b/libzazen/lib_input.c
@@ -12,6 +12,23 @@
 #include "types.h"
 #include "util.h"
 
+static void handle_pointer_motion(struct zazen_seat *seat,
+                                  struct libinput_event_pointer *pointer_event)
+{
+  struct zazen_ray_motion_event event = {0};
+  double dx, dy;
+
+  dx = libinput_event_pointer_get_dx(pointer_event);
+  dy = libinput_event_pointer_get_dy(pointer_event);
+
+  event = (struct zazen_ray_motion_event){
+      .begin_delta = (Point){0, 0, 0},
+      .end_delta = (Point){dx / 10, -dy / 10, 0},
+  };
+
+  zazen_ray_notify_motion(seat->ray, &event);
+}
+
 static void handle_device_added(struct zazen_seat *seat,
                                 struct libinput_device *device)
 {
@@ -29,21 +46,12 @@ static void handle_device_added(struct zazen_seat *seat,
   }
 }
 
-static void handle_pointer_motion(struct zazen_seat *seat,
-                                  struct libinput_event_pointer *pointer_event)
+static void handle_device_removed(struct zazen_seat *seat,
+                                  struct libinput_device *device)
 {
-  struct zazen_ray_motion_event event = {0};
-  double dx, dy;
-
-  dx = libinput_event_pointer_get_dx(pointer_event);
-  dy = libinput_event_pointer_get_dy(pointer_event);
-
-  event = (struct zazen_ray_motion_event){
-      .begin_delta = (Point){0, 0, 0},
-      .end_delta = (Point){dx / 10, -dy / 10, 0},
-  };
-
-  zazen_ray_notify_motion(seat->ray, &event);
+  UNUSED(seat);
+  UNUSED(device);
+  // TODO: handle remove device
 }
 
 static int handle_event(int fd, uint32_t mask, void *data)
@@ -67,10 +75,12 @@ static int handle_event(int fd, uint32_t mask, void *data)
         handle_device_added(libinput->seat, libinput_event_get_device(event));
         break;
       case LIBINPUT_EVENT_DEVICE_REMOVED:
+        handle_device_removed(libinput->seat, libinput_event_get_device(event));
         break;
       default:
         break;
     }
+    // TODO: Handle remove keyboard, ray;
     libinput_event_destroy(event);
     result = 0;
   }

--- a/libzazen/meson.build
+++ b/libzazen/meson.build
@@ -10,6 +10,7 @@ srcs_libzazen = files([
   'callback.c',
   'compositor.c',
   'cuboid_window.c',
+  'keyboard_client.c',
   'keyboard.c',
   'lib_input.c',
   'opengl_render_component_manager.c',

--- a/libzazen/ray.c
+++ b/libzazen/ray.c
@@ -3,6 +3,7 @@
 #include "opengl_render_component_back_state.h"
 #include "seat.h"
 #include "util.h"
+#include "z11-input-server-protocol.h"
 
 static const char* fragment_shader;
 static const char* vertex_shader;
@@ -15,13 +16,13 @@ static void grab_ray_button(struct zazen_ray_grab* grab,
   UNUSED(time);
   UNUSED(button);
   UNUSED(state);
-  // TODO
+  // TODO: send event to client
 }
 
 static void grab_ray_focus(struct zazen_ray_grab* grab)
 {
   UNUSED(grab);
-  // TODO
+  // TODO: send event to client
 }
 
 void zazen_ray_notify_motion(struct zazen_ray* ray,
@@ -46,6 +47,8 @@ static void grab_ray_motion(struct zazen_ray_grab* grab,
                                              sizeof(Line), sizeof(Point));
 
   zazen_opengl_render_item_commit(grab->ray->render_item);
+
+  // TODO: send event to client
 }
 
 static void grab_ray_axis(struct zazen_ray_grab* grab,
@@ -55,7 +58,7 @@ static void grab_ray_axis(struct zazen_ray_grab* grab,
   UNUSED(grab);
   UNUSED(time);
   UNUSED(event);
-  // TODO
+  // TODO: send event to client
 }
 
 static void grab_ray_axis_source(struct zazen_ray_grab* grab,
@@ -63,19 +66,19 @@ static void grab_ray_axis_source(struct zazen_ray_grab* grab,
 {
   UNUSED(grab);
   UNUSED(source);
-  // TODO
+  // TODO: send event to client
 }
 
 static void grab_ray_frame(struct zazen_ray_grab* grab)
 {
   UNUSED(grab);
-  // TODO
+  // TODO: send event to client
 }
 
 static void grab_ray_cancel(struct zazen_ray_grab* grab)
 {
   UNUSED(grab);
-  // TODO
+  // TODO: send event to client
 }
 
 static const struct zazen_ray_grab_interface ray_grab_interface = {

--- a/libzazen/ray_client.c
+++ b/libzazen/ray_client.c
@@ -65,6 +65,8 @@ struct zazen_ray_client *zazen_ray_client_create(struct zazen_ray *ray,
   ray_client->ray_destroy_signal_listener.notify = ray_destroy_signal_handler;
   wl_signal_add(&ray->destroy_signal, &ray_client->ray_destroy_signal_listener);
 
+  wl_list_insert(&ray->ray_clients, &ray_client->link);
+
   return ray_client;
 
 out:

--- a/libzazen/ray_client.c
+++ b/libzazen/ray_client.c
@@ -24,14 +24,13 @@ static void zazen_ray_client_protocol_release(struct wl_client *client,
 }
 
 static const struct z11_ray_interface zazen_ray_interface = {
-    .release = zazen_ray_client_protocol_release};
+    .release = zazen_ray_client_protocol_release,
+};
 
 static void ray_destroy_signal_handler(struct wl_listener *listener, void *data)
 {
   UNUSED(data);
   struct zazen_ray_client *ray_client;
-
-  // TODO: Handle error that ray is destroyed before ray_client associated;
 
   ray_client =
       wl_container_of(listener, ray_client, ray_destroy_signal_listener);
@@ -71,7 +70,7 @@ struct zazen_ray_client *zazen_ray_client_create(struct zazen_ray *ray,
 out:
   free(ray_client);
 
-  return ray_client;
+  return NULL;
 }
 
 static void zazen_ray_client_destroy(struct zazen_ray_client *ray_client)

--- a/libzazen/seat.c
+++ b/libzazen/seat.c
@@ -112,8 +112,6 @@ static void zazen_seat_protocol_get_ray(struct wl_client* client,
     zazen_log("Failed to get a ray");
     return;
   }
-
-  wl_list_insert(&seat->ray->ray_clients, &ray_client->link);
 }
 
 static void zazen_seat_protocol_get_keyboard(struct wl_client* client,
@@ -137,8 +135,6 @@ static void zazen_seat_protocol_get_keyboard(struct wl_client* client,
     zazen_log("Failed to get a keyboard");
     return;
   }
-
-  wl_list_insert(&seat->keyboard->keyboard_clients, &keyboard_client->link);
 }
 
 static const struct z11_seat_interface zazen_seat_interface = {
@@ -214,7 +210,6 @@ out:
 
 void zazen_seat_destroy(struct zazen_seat* seat)
 {
-  wl_list_remove(&seat->client_list);
   if (seat->ray) zazen_ray_destroy(seat->ray);
   if (seat->keyboard) zazen_keyboard_destroy(seat->keyboard);
   if (seat->libinput) zazen_libinput_destroy(seat->libinput);

--- a/libzazen/seat.c
+++ b/libzazen/seat.c
@@ -1,9 +1,25 @@
 #include "seat.h"
 
 #include <string.h>
+#include <wayland-server.h>
 
 #include "util.h"
 #include "z11-input-server-protocol.h"
+
+void zazen_seat_send_updated_capability(struct zazen_seat* seat)
+{
+  enum z11_seat_capability capability = 0;
+  struct wl_resource* resource;
+
+  if (seat->keyboard_device_count > 0)
+    capability |= Z11_SEAT_CAPABILITY_KEYBOARD;
+  if (seat->ray_device_count > 0) capability |= Z11_SEAT_CAPABILITY_RAY;
+
+  wl_resource_for_each(resource, &seat->client_list)
+  {
+    z11_seat_send_capability(resource, capability);
+  }
+}
 
 bool zazen_seat_init_keyboard(struct zazen_seat* seat)
 {
@@ -24,14 +40,14 @@ bool zazen_seat_init_keyboard(struct zazen_seat* seat)
   seat->keyboard_device_count = 1;
   keyboard->seat = seat;
 
+  zazen_seat_send_updated_capability(seat);
+
   return true;
 }
 
 bool zazen_seat_init_ray(struct zazen_seat* seat)
 {
   struct zazen_ray* ray;
-
-  // TODO: Handle capabilities
 
   if (seat->ray) {
     seat->ray_device_count += 1;
@@ -48,7 +64,31 @@ bool zazen_seat_init_ray(struct zazen_seat* seat)
   seat->ray_device_count = 1;
   ray->seat = seat;
 
+  zazen_seat_send_updated_capability(seat);
+
   return true;
+}
+
+void zazen_seat_release_ray(struct zazen_seat* seat)
+{
+  seat->ray_device_count--;
+  if (seat->ray_device_count == 0) {
+    zazen_ray_destroy(seat->ray);
+    seat->ray = NULL;
+
+    zazen_seat_send_updated_capability(seat);
+  }
+}
+
+void zazen_seat_release_keyboard(struct zazen_seat* seat)
+{
+  seat->keyboard_device_count--;
+  if (seat->keyboard_device_count == 0) {
+    zazen_keyboard_destroy(seat->keyboard);
+    seat->keyboard = NULL;
+
+    zazen_seat_send_updated_capability(seat);
+  }
 }
 
 static void zazen_seat_protocol_get_ray(struct wl_client* client,
@@ -106,20 +146,34 @@ static const struct z11_seat_interface zazen_seat_interface = {
     .get_keyboard = zazen_seat_protocol_get_keyboard,
 };
 
+static void zazen_seat_unbind(struct wl_resource* resource)
+{
+  wl_list_remove(wl_resource_get_link(resource));
+}
+
 static void zazen_seat_bind(struct wl_client* client, void* data,
                             uint32_t version, uint32_t id)
 {
   struct zazen_seat* seat = data;
   struct wl_resource* resource;
+  enum z11_seat_capability capability = 0;
 
   resource = wl_resource_create(client, &z11_seat_interface, version, id);
-
   if (resource == NULL) {
     wl_client_post_no_memory(client);
     return;
   }
 
-  wl_resource_set_implementation(resource, &zazen_seat_interface, seat, NULL);
+  wl_resource_set_implementation(resource, &zazen_seat_interface, seat,
+                                 zazen_seat_unbind);
+
+  wl_list_insert(&seat->client_list, wl_resource_get_link(resource));
+
+  if (seat->keyboard_device_count > 0)
+    capability |= Z11_SEAT_CAPABILITY_KEYBOARD;
+  if (seat->ray_device_count > 0) capability |= Z11_SEAT_CAPABILITY_RAY;
+
+  z11_seat_send_capability(resource, capability);
 }
 
 struct zazen_seat* zazen_seat_create(
@@ -132,6 +186,8 @@ struct zazen_seat* zazen_seat_create(
   if (seat == NULL) return NULL;
 
   seat->render_component_manager = render_component_manager;
+
+  wl_list_init(&seat->client_list);
 
   seat->ray = NULL;
   seat->keyboard = NULL;
@@ -158,6 +214,7 @@ out:
 
 void zazen_seat_destroy(struct zazen_seat* seat)
 {
+  wl_list_remove(&seat->client_list);
   if (seat->ray) zazen_ray_destroy(seat->ray);
   if (seat->keyboard) zazen_keyboard_destroy(seat->keyboard);
   if (seat->libinput) zazen_libinput_destroy(seat->libinput);

--- a/libzazen/seat.h
+++ b/libzazen/seat.h
@@ -2,8 +2,10 @@
 #define LIBZAZEN_SEAT_H
 
 #include "keyboard.h"
+#include "keyboard_client.h"
 #include "lib_input.h"
 #include "ray.h"
+#include "ray_client.h"
 
 struct zazen_seat {
   struct zazen_opengl_render_component_manager *render_component_manager;

--- a/libzazen/seat.h
+++ b/libzazen/seat.h
@@ -10,6 +10,8 @@
 struct zazen_seat {
   struct zazen_opengl_render_component_manager *render_component_manager;
 
+  struct wl_list client_list;
+
   struct zazen_ray *ray;
   struct zazen_keyboard *keyboard;
 
@@ -24,6 +26,10 @@ struct zazen_seat {
 bool zazen_seat_init_ray(struct zazen_seat *seat);
 
 bool zazen_seat_init_keyboard(struct zazen_seat *seat);
+
+void zazen_seat_release_ray(struct zazen_seat *seat);
+
+void zazen_seat_release_keyboard(struct zazen_seat *seat);
 
 struct zazen_seat *zazen_seat_create(
     struct wl_display *display,

--- a/protocol/z11_input.xml
+++ b/protocol/z11_input.xml
@@ -104,7 +104,7 @@
       <entry name="pressed" value="1" summary="key is pressed"/>
     </enum>
 
-        <enum name="key_state">
+    <enum name="key_state">
       <description summary="physical key state">
 	Describes the physical state of a key that produced the key event.
       </description>

--- a/protocol/z11_input.xml
+++ b/protocol/z11_input.xml
@@ -19,6 +19,11 @@
       <description summary="return ray object">TBD</description>
       <arg name="id" type="new_id" interface="z11_ray" summary="seat ray"/>
     </request>
+
+    <request name="get_keyboard">
+      <description summary="return keyboard object">TBD</description>
+      <arg name="id" type="new_id" interface="z11_keyboard" summary="seat keyboard"/>
+    </request>
   </interface>
 
   <interface name="z11_ray" version="1">
@@ -72,6 +77,73 @@
 
     <request name="release" type="destructor">
       <description summary="release the ray object">TBD</description>
+    </request>
+  </interface>
+
+  <interface name="z11_keyboard" version="1">
+    <description summary="keyboard input device">TBD</description>
+
+    <event name="enter">
+      <description summary="enter event">TBD</description>
+      <arg name="serial" type="uint" summary="serial number of the enter event"/>
+      <arg name="cuboid_window" type="object" interface="z11_cuboid_window"/>
+      <arg name="keys" type="array" summary="the currently pressed keys"/>
+    </event>
+
+    <event name="leave">
+      <description summary="leave event">TBD</description>
+      <arg name="serial" type="uint" summary="serial number of the leave event"/>
+      <arg name="cuboid_window" type="object" interface="z11_cuboid_window"/>
+    </event>
+
+    <enum name="key_state">
+      <description summary="physical key state">
+	Describes the physical state of a key that produced the key event.
+      </description>
+      <entry name="released" value="0" summary="key is not pressed"/>
+      <entry name="pressed" value="1" summary="key is pressed"/>
+    </enum>
+
+        <enum name="key_state">
+      <description summary="physical key state">
+	Describes the physical state of a key that produced the key event.
+      </description>
+      <entry name="released" value="0" summary="key is not pressed"/>
+      <entry name="pressed" value="1" summary="key is pressed"/>
+    </enum>
+
+    <event name="key">
+      <description summary="key event">
+	A key was pressed or released.
+	The time argument is a timestamp with millisecond
+	granularity, with an undefined base.
+
+	The key is a platform-specific key code that can be interpreted
+	by feeding it to the keyboard mapping (see the keymap event).
+
+	If this event produces a change in modifiers, then the resulting
+	wl_keyboard.modifiers event must be sent after this event.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the key event"/>
+      <arg name="time" type="uint" summary="timestamp with millisecond granularity"/>
+      <arg name="key" type="uint" summary="key that produced the event"/>
+      <arg name="state" type="uint" enum="key_state" summary="physical state of the key"/>
+    </event>
+
+    <event name="modifiers">
+      <description summary="modifier and group state">
+	Notifies clients that the modifier and/or group state has
+	changed, and it should update its local state.
+      </description>
+      <arg name="serial" type="uint" summary="serial number of the modifiers event"/>
+      <arg name="mods_depressed" type="uint" summary="depressed modifiers"/>
+      <arg name="mods_latched" type="uint" summary="latched modifiers"/>
+      <arg name="mods_locked" type="uint" summary="locked modifiers"/>
+      <arg name="group" type="uint" summary="keyboard layout"/>
+    </event>
+
+    <request name="release" type="destructor">
+      <description summary="release the keyboard object"/>
     </request>
   </interface>
 </protocol>


### PR DESCRIPTION
キーボードを追加。
Rayと同様、clientの情報をkeyboard_clientとして保持するようにした。
Rayとは異なり今はKeyboardの描画情報は持たないようにした。
どのClientにフォーカスしているかは追ってPR出します。

Keyboard以外の部分だと、
- Ray側に見つけた多少のバグの修正
- Libinputのデバイスの削除のイベントの扱い
- capabilityのeventの送信部分を実装
  - capabilityを送信するためにseatにもclientの情報を付与した。

をしてます（commitあまり分けられておらずすまん。）