### PR TITLE
Complete ray creation

### DIFF
--- a/libzazen/ray.c
+++ b/libzazen/ray.c
@@ -164,6 +164,7 @@ void zazen_ray_destroy(struct zazen_ray* ray)
 {
   wl_signal_emit(&ray->destroy_signal, ray);
   if (ray->render_item) zazen_opengl_render_item_destroy(ray->render_item);
+  wl_list_remove(&ray->zazen_cuboid_window_destroy_listener.link);
   free(ray);
 }
 

--- a/libzazen/ray_client.c
+++ b/libzazen/ray_client.c
@@ -7,25 +7,27 @@
 
 static void zazen_ray_client_destroy(struct zazen_ray_client *ray_client);
 
-static void zazen_ray_client_handle_destroy(struct wl_resource *resource)
-{
-  struct zazen_ray_client *ray_client;
-
-  ray_client = wl_resource_get_user_data(resource);
-
-  zazen_ray_client_destroy(ray_client);
-}
-
 static void zazen_ray_client_protocol_release(struct wl_client *client,
                                               struct wl_resource *resource)
 {
   UNUSED(client);
+  wl_list_remove(wl_resource_get_link(resource));
   wl_resource_destroy(resource);
 }
 
 static const struct z11_ray_interface zazen_ray_interface = {
     .release = zazen_ray_client_protocol_release,
 };
+
+static void client_destroy_handler(struct wl_listener *listener, void *data)
+{
+  UNUSED(data);
+  struct zazen_ray_client *ray_client;
+
+  ray_client = wl_container_of(listener, ray_client, client_destroy_listener);
+
+  zazen_ray_client_destroy(ray_client);
+}
 
 static void ray_destroy_signal_handler(struct wl_listener *listener, void *data)
 {
@@ -35,15 +37,35 @@ static void ray_destroy_signal_handler(struct wl_listener *listener, void *data)
   ray_client =
       wl_container_of(listener, ray_client, ray_destroy_signal_listener);
 
-  wl_resource_destroy(ray_client->resource);
+  zazen_ray_client_destroy(ray_client);
+}
+
+void zazen_ray_client_add_resource(struct zazen_ray_client *ray_client,
+                                   struct wl_resource *resource)
+{
+  wl_resource_set_implementation(resource, &zazen_ray_interface, ray_client,
+                                 NULL);
+
+  wl_list_insert(&ray_client->ray_resources, wl_resource_get_link(resource));
+}
+
+static struct zazen_ray_client *zazen_ray_client_find(struct zazen_ray *ray,
+                                                      struct wl_client *client)
+{
+  struct zazen_ray_client *ray_client;
+
+  wl_list_for_each(ray_client, &ray->ray_clients, link)
+  {
+    if (ray_client->client == client) return ray_client;
+  }
+
+  return NULL;
 }
 
 struct zazen_ray_client *zazen_ray_client_create(struct zazen_ray *ray,
-                                                 struct wl_client *client,
-                                                 uint32_t id)
+                                                 struct wl_client *client)
 {
   struct zazen_ray_client *ray_client;
-  struct wl_resource *resource;
 
   ray_client = zalloc(sizeof *ray_client);
   if (ray_client == NULL) {
@@ -51,16 +73,13 @@ struct zazen_ray_client *zazen_ray_client_create(struct zazen_ray *ray,
     return NULL;
   }
 
-  resource = wl_resource_create(client, &z11_ray_interface, 1, id);
-  if (resource == NULL) {
-    wl_client_post_no_memory(client);
-    goto out;
-  }
+  ray_client->client = client;
 
-  wl_resource_set_implementation(resource, &zazen_ray_interface, ray_client,
-                                 zazen_ray_client_handle_destroy);
+  wl_list_init(&ray_client->ray_resources);
 
-  ray_client->resource = resource;
+  ray_client->client_destroy_listener.notify = client_destroy_handler;
+  wl_client_add_destroy_listener(ray_client->client,
+                                 &ray_client->client_destroy_listener);
 
   ray_client->ray_destroy_signal_listener.notify = ray_destroy_signal_handler;
   wl_signal_add(&ray->destroy_signal, &ray_client->ray_destroy_signal_listener);
@@ -68,16 +87,38 @@ struct zazen_ray_client *zazen_ray_client_create(struct zazen_ray *ray,
   wl_list_insert(&ray->ray_clients, &ray_client->link);
 
   return ray_client;
+}
 
-out:
-  free(ray_client);
+struct zazen_ray_client *zazen_ray_client_find_or_create(
+    struct zazen_ray *ray, struct wl_client *client)
+{
+  struct zazen_ray_client *ray_client;
 
-  return NULL;
+  ray_client = zazen_ray_client_find(ray, client);
+  if (ray_client) return ray_client;
+
+  ray_client = zazen_ray_client_create(ray, client);
+  if (ray_client == NULL) {
+    wl_client_post_no_memory(client);
+    return NULL;
+  }
+
+  return ray_client;
 }
 
 static void zazen_ray_client_destroy(struct zazen_ray_client *ray_client)
 {
+  struct wl_resource *resource;
+
+  wl_resource_for_each(resource, &ray_client->ray_resources)
+  {
+    wl_resource_set_user_data(resource, NULL);
+  }
+
+  wl_list_remove(&ray_client->client_destroy_listener.link);
   wl_list_remove(&ray_client->ray_destroy_signal_listener.link);
+
   wl_list_remove(&ray_client->link);
+
   free(ray_client);
 }

--- a/libzazen/ray_client.h
+++ b/libzazen/ray_client.h
@@ -7,13 +7,17 @@
 
 struct zazen_ray_client {
   struct wl_list link;
-  struct wl_resource* resource;
+  struct wl_client* client;
+  struct wl_list ray_resources;
 
+  struct wl_listener client_destroy_listener;
   struct wl_listener ray_destroy_signal_listener;
 };
 
-struct zazen_ray_client* zazen_ray_client_create(struct zazen_ray* ray,
-                                                 struct wl_client* client,
-                                                 uint32_t id);
+struct zazen_ray_client* zazen_ray_client_find_or_create(
+    struct zazen_ray* ray, struct wl_client* client);
+
+void zazen_ray_client_add_resource(struct zazen_ray_client* ray_client,
+                                   struct wl_resource* resource);
 
 #endif  // LIBZAZEN_RAY_CLIENT_H

--- a/libzazen/seat.c
+++ b/libzazen/seat.c
@@ -98,21 +98,27 @@ static void zazen_seat_protocol_get_ray(struct wl_client* client,
 {
   struct zazen_seat* seat;
   struct zazen_ray_client* ray_client;
+  struct wl_resource* ray_client_resource;
+
+  ray_client_resource = wl_resource_create(client, &z11_ray_interface, 1, id);
+  if (ray_client_resource == NULL) {
+    wl_client_post_no_memory(client);
+    return;
+  }
 
   seat = wl_resource_get_user_data(resource);
-
   if (seat->ray == NULL) {
-    zazen_log("The ray is unavailable");
+    zazen_log("A ray is unavailable\n");
     return;
   }
 
-  // TODO: Handle the case ray client already created
-  ray_client = zazen_ray_client_create(seat->ray, client, id);
+  ray_client = zazen_ray_client_find_or_create(seat->ray, client);
   if (ray_client == NULL) {
     wl_client_post_no_memory(client);
-    zazen_log("Failed to get a ray");
     return;
   }
+
+  zazen_ray_client_add_resource(ray_client, ray_client_resource);
 }
 
 static void zazen_seat_protocol_get_keyboard(struct wl_client* client,


### PR DESCRIPTION
fix #63 

rayが複数のray_client（ `struct zazen_ray_client` ）を持つ
ray_clientが複数のray_resource（ `struct wl_resource` ）を持つ

- seat.get_ray をそのclientが最初に行った時 -> ray_clientを作成
- client が destroyされた時、rayが削除された時 -> ray_clientを削除
  - clientがdestroyされた時: ray_clientとその配下のray_resourceをすべて削除
  - rayが削除された時: ray_clientのみを削除、ray_resourceのuser_dataをNULLに

- seat.get_ray時 -> ray_resourceを作成
- ray.release時 -> ray_resourceを削除