### PR TITLE
Add keymap event to Keyboard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update &&
-          sudo apt-get install libglew-dev libsdl2-dev libopenvr-dev libudev-dev libinput-dev
+          sudo apt-get install libglew-dev libsdl2-dev libopenvr-dev libudev-dev libinput-dev libxkbcommon-dev
       - uses: actions/checkout@v2
         with:
           path: main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,33 +11,21 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update &&
-          sudo apt-get install libglew-dev libsdl2-dev libopenvr-dev libudev-dev libinput-dev libxkbcommon-dev
+          sudo apt-get install libwayland-dev libglew-dev libsdl2-dev libopenvr-dev libudev-dev libinput-dev libxkbcommon-dev
       - uses: actions/checkout@v2
         with:
           path: main
-      - uses: actions/checkout@v2
-        with:
-          repository: gray-armor/wayland
-          path: wayland
       - uses: actions/setup-python@v1
         with:
           python-version: "3.x"
+
       - run: pip install meson ninja
 
-      - run: meson -Ddocumentation=false -Dtests=false -Ddtd_validation=false -Dicon_directory=false --prefix=$(pwd)/target build
-        working-directory: ./wayland
-        env:
-          CC: gcc
-      - run: ninja -C build install
-        working-directory: ./wayland
-      - run: |
-          echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/wayland/target/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
-
-      - run: |
-          meson build
+      - run: meson build
         working-directory: ./main
         env:
           CC: gcc
+
       - run: ninja -C build test
         working-directory: ./main
 

--- a/clients/helper.c
+++ b/clients/helper.c
@@ -22,40 +22,79 @@ struct wl_shm_listener shm_listener = {
     shm_format,
 };
 
-static void handle_enter(void *data, struct z11_ray *ray, uint32_t serial,
-                         struct z11_cuboid_window *cuboid_window,
-                         int32_t ray_origin_x, int32_t ray_origin_y,
-                         int32_t ray_origin_z, int32_t ray_direction_x,
-                         int32_t ray_direction_y, int32_t ray_direction_z)
+static void handle_ray_enter(void *data, struct z11_ray *ray, uint32_t serial,
+                             struct z11_cuboid_window *cuboid_window,
+                             int32_t ray_origin_x, int32_t ray_origin_y,
+                             int32_t ray_origin_z, int32_t ray_direction_x,
+                             int32_t ray_direction_y, int32_t ray_direction_z)
 {}
 
-static void handle_leave(void *data, struct z11_ray *ray, uint32_t serial,
-                         struct z11_cuboid_window *cuboid_window)
+static void handle_ray_leave(void *data, struct z11_ray *ray, uint32_t serial,
+                             struct z11_cuboid_window *cuboid_window)
 {}
 
-static void handle_motion(void *data, struct z11_ray *ray, uint32_t time,
-                          int32_t ray_origin_x, int32_t ray_origin_y,
-                          int32_t ray_origin_z, int32_t ray_direction_x,
-                          int32_t ray_direction_y, int32_t ray_direction_z)
+static void handle_ray_motion(void *data, struct z11_ray *ray, uint32_t time,
+                              int32_t ray_origin_x, int32_t ray_origin_y,
+                              int32_t ray_origin_z, int32_t ray_direction_x,
+                              int32_t ray_direction_y, int32_t ray_direction_z)
 {}
 
-static void handle_button(void *data, struct z11_ray *ray, uint32_t serial,
-                          uint32_t time, uint32_t button, uint32_t state)
+static void handle_ray_button(void *data, struct z11_ray *ray, uint32_t serial,
+                              uint32_t time, uint32_t button, uint32_t state)
 {}
 
 struct z11_ray_listener ray_listener = {
-    .enter = handle_enter,
-    .leave = handle_leave,
-    .motion = handle_motion,
-    .button = handle_button,
+    .enter = handle_ray_enter,
+    .leave = handle_ray_leave,
+    .motion = handle_ray_motion,
+    .button = handle_ray_button,
 };
+
+static void handle_keyboard_keymap(void *data, struct z11_keyboard *keyboard,
+                                   uint32_t format, int fd, uint32_t size)
+{}
+
+static void handle_keyboard_enter(void *data, struct z11_keyboard *keyboard,
+                                  uint32_t serial,
+                                  struct z11_cuboid_window *cuboid_window,
+                                  struct wl_array *keys)
+{}
+
+static void handle_keyboard_leave(void *data, struct z11_keyboard *keyboard,
+                                  uint32_t serial,
+                                  struct z11_cuboid_window *cuboid_window)
+{}
+
+static void handle_keyboard_key(void *data, struct z11_keyboard *keyboard,
+                                uint32_t serial, uint32_t time, uint32_t key,
+                                uint32_t state)
+{}
+
+static void handle_keyboard_modifiers(void *data, struct z11_keyboard *keyboard,
+                                      uint32_t serial, uint32_t mods_depressed,
+                                      uint32_t mods_latached,
+                                      uint32_t mods_locked, uint32_t group)
+{}
+
+struct z11_keyboard_listener keyboard_listener = {
+    .keymap = handle_keyboard_keymap,
+    .enter = handle_keyboard_enter,
+    .leave = handle_keyboard_leave,
+    .key = handle_keyboard_key,
+    .modifiers = handle_keyboard_modifiers};
 
 void handle_capability(void *data, struct z11_seat *seat, uint32_t capabilities)
 {
   struct z11_ray *ray;
+  struct z11_keyboard *keyboard;
+
   if (capabilities & Z11_SEAT_CAPABILITY_RAY) {
     ray = z11_seat_get_ray(seat);
     z11_ray_add_listener(ray, &ray_listener, data);
+  }
+  if (capabilities & Z11_SEAT_CAPABILITY_KEYBOARD) {
+    keyboard = z11_seat_get_keyboard(seat);
+    z11_keyboard_add_listener(keyboard, &keyboard_listener, data);
   }
 }
 

--- a/clients/png_viewer.cc
+++ b/clients/png_viewer.cc
@@ -270,6 +270,10 @@ void PngViewer::HandleRayButton(struct z11_ray *ray, uint32_t serial,
                                 uint32_t time, uint32_t button, uint32_t state)
 {}
 
+void PngViewer::HandleKeyboardKeymap(struct z11_keyboard *keyboard,
+                                     uint32_t format, int fd, uint32_t size)
+{}
+
 void PngViewer::HandleKeyboardEnter(struct z11_keyboard *keyboard,
                                     uint32_t serial,
                                     struct z11_cuboid_window *cuboid_window,

--- a/clients/png_viewer.h
+++ b/clients/png_viewer.h
@@ -61,6 +61,8 @@ class PngViewer
                       struct z11_cuboid_window *cuboid_window);
   void HandleRayButton(struct z11_ray *ray, uint32_t serial, uint32_t time,
                        uint32_t button, uint32_t state);
+  void HandleKeyboardKeymap(struct z11_keyboard *keyboard, uint32_t format,
+                            int fd, uint32_t size);
   void HandleKeyboardEnter(struct z11_keyboard *keyboard, uint32_t serial,
                            struct z11_cuboid_window *cuboid_window,
                            struct wl_array *keys);

--- a/clients/simple_box.cc
+++ b/clients/simple_box.cc
@@ -424,6 +424,10 @@ float SimpleBox::RayIntersection(Face face)
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+void SimpleBox::HandleKeyboardKeymap(struct z11_keyboard *keyboard,
+                                     uint32_t format, int fd, uint32_t size)
+{}
+
 void SimpleBox::HandleKeyboardEnter(struct z11_keyboard *keyboard,
                                     uint32_t serial,
                                     struct z11_cuboid_window *cuboid_window,

--- a/clients/simple_box.h
+++ b/clients/simple_box.h
@@ -58,6 +58,8 @@ class SimpleBox
   void HandleRayButton(struct z11_ray *ray, uint32_t serial, uint32_t time,
                        uint32_t button, uint32_t state);
   float RayIntersection(Face face);
+  void HandleKeyboardKeymap(struct z11_keyboard *keyboard, uint32_t format,
+                            int fd, uint32_t size);
   void HandleKeyboardEnter(struct z11_keyboard *keyboard, uint32_t serial,
                            struct z11_cuboid_window *cuboid_window,
                            struct wl_array *keys);

--- a/clients/z_window.h
+++ b/clients/z_window.h
@@ -37,6 +37,8 @@ class ZWindow
                       struct z11_cuboid_window *cuboid_window);
   void HandleRayButton(struct z11_ray *ray, uint32_t serial, uint32_t time,
                        uint32_t button, uint32_t state);
+  void HandleKeyboardKeymap(struct z11_keyboard *keyboard, uint32_t format,
+                            int fd, uint32_t size);
   void HandleKeyboardEnter(struct z11_keyboard *keyboard, uint32_t serial,
                            struct z11_cuboid_window *cuboid_window,
                            struct wl_array *keys);
@@ -191,6 +193,14 @@ static const struct z11_ray_listener ray_listener = {
 };
 
 template <class T>
+static void handle_keyboard_keymap(void *data, struct z11_keyboard *keyboard,
+                                   uint32_t format, int fd, uint32_t size)
+{
+  ZWindow<T> *zwindow = (ZWindow<T> *)data;
+  zwindow->HandleKeyboardKeymap(keyboard, format, fd, size);
+}
+
+template <class T>
 static void handle_keyboard_enter(void *data, struct z11_keyboard *keyboard,
                                   uint32_t serial,
                                   struct z11_cuboid_window *cuboid_window,
@@ -231,9 +241,8 @@ static void handle_keyboard_modifiers(void *data, struct z11_keyboard *keyboard,
 
 template <class T>
 static const struct z11_keyboard_listener keyboard_listener = {
-    handle_keyboard_enter<T>,
-    handle_keyboard_leave<T>,
-    handle_keyboard_key<T>,
+    handle_keyboard_keymap<T>,    handle_keyboard_enter<T>,
+    handle_keyboard_leave<T>,     handle_keyboard_key<T>,
     handle_keyboard_modifiers<T>,
 };
 
@@ -361,6 +370,13 @@ void ZWindow<T>::HandleRayButton(struct z11_ray *ray, uint32_t serial,
                                  uint32_t time, uint32_t button, uint32_t state)
 {
   delegate_->HandleRayButton(ray, serial, time, button, state);
+}
+
+template <class T>
+void ZWindow<T>::HandleKeyboardKeymap(struct z11_keyboard *keyboard,
+                                      uint32_t format, int fd, uint32_t size)
+{
+  delegate_->HandleKeyboardKeymap(keyboard, format, fd, size);
 }
 
 template <class T>

--- a/libzazen/keyboard.c
+++ b/libzazen/keyboard.c
@@ -16,7 +16,6 @@ void zazen_keyboard_notify_keymap(struct zazen_keyboard* keyboard,
   struct zazen_keymap_info* info;
 
   info = keyboard->keymap_info;
-  if (info == NULL) return;
 
   wl_resource_for_each(resource, &keyboard_client->keyboard_resources)
   {
@@ -170,7 +169,7 @@ out:
 void zazen_keyboard_destroy(struct zazen_keyboard* keyboard)
 {
   wl_array_release(&keyboard->keys);
-  if (keyboard->keymap_info) zazen_keymap_info_destroy(keyboard->keymap_info);
+  zazen_keymap_info_destroy(keyboard->keymap_info);
   wl_signal_emit(&keyboard->destroy_signal, keyboard);
   wl_list_remove(&keyboard->focus_cuboid_window_destroy_listener.link);
   free(keyboard);

--- a/libzazen/keyboard.h
+++ b/libzazen/keyboard.h
@@ -5,6 +5,8 @@
 #include <time.h>
 #include <wayland-server.h>
 
+#include "keymap_info.h"
+
 struct zazen_keyboard_grab;
 struct zazen_keyboard_grab_interface {
   void (*key)(struct zazen_keyboard_grab *grab, const struct timespec *time,
@@ -26,6 +28,8 @@ struct zazen_keyboard {
 
   struct wl_array keys;
 
+  struct zazen_keymap_info *keymap_info;
+
   struct wl_list keyboard_clients;
   struct wl_signal destroy_signal;
 
@@ -38,6 +42,10 @@ struct zazen_keyboard_client *zazen_keyboard_find_keyboard_client(
 
 void zazen_keyboard_set_focus_cuboid_window(
     struct zazen_keyboard *keyboard, struct zazen_cuboid_window *cuboid_window);
+
+void zazen_keyboard_notify_keymap(
+    struct zazen_keyboard *keyboard,
+    struct zazen_keyboard_client *keyboard_client);
 
 void zazen_keyboard_notify_key(struct zazen_keyboard *keyboard,
                                const struct timespec *time, uint32_t key,

--- a/libzazen/keymap_info.c
+++ b/libzazen/keymap_info.c
@@ -1,0 +1,66 @@
+#include "keymap_info.h"
+
+#include <string.h>
+#include <unistd.h>
+#include <xkbcommon/xkbcommon.h>
+
+#include "util.h"
+
+struct zazen_keymap_info *zazen_keymap_info_create()
+{
+  struct zazen_keymap_info *info;
+  char *keymap_string;
+  size_t keymap_size;
+
+  info = zalloc(sizeof *info);
+  if (info == NULL) return NULL;
+
+  info->context = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+  if (info->context == NULL) {
+    zazen_log("Failed to create XKB context\n");
+    goto out;
+  }
+
+  info->names = NULL;
+
+  info->keymap = xkb_keymap_new_from_names(info->context, info->names,
+                                           XKB_KEYMAP_COMPILE_NO_FLAGS);
+  if (info->keymap == NULL) {
+    zazen_log("Failed to create XKB keymap\n");
+    goto out;
+  }
+
+  keymap_string =
+      xkb_keymap_get_as_string(info->keymap, XKB_KEYMAP_FORMAT_TEXT_V1);
+  if (keymap_string == NULL) {
+    zazen_log("Failed to get string version of keymap\n");
+    goto out;
+  }
+
+  keymap_size = strlen(keymap_string) + 1;
+
+  info->size = keymap_size;
+  info->fd = create_shared_file(info->size, keymap_string);
+  if (info->fd < 0) {
+    zazen_log("Failed to create file\n");
+    free(keymap_string);
+    goto out;
+  }
+  info->format = Z11_KEYBOARD_KEYMAP_FORMAT_XKB_V1;
+
+  free(keymap_string);
+
+  return info;
+
+out:
+  free(info);
+
+  return NULL;
+}
+
+void zazen_keymap_info_destroy(struct zazen_keymap_info *info)
+{
+  xkb_keymap_unref(info->keymap);
+  close(info->fd);
+  free(info);
+}

--- a/libzazen/keymap_info.c
+++ b/libzazen/keymap_info.c
@@ -61,6 +61,7 @@ out:
 void zazen_keymap_info_destroy(struct zazen_keymap_info *info)
 {
   xkb_keymap_unref(info->keymap);
+  xkb_context_unref(info->context);
   close(info->fd);
   free(info);
 }

--- a/libzazen/keymap_info.h
+++ b/libzazen/keymap_info.h
@@ -1,0 +1,21 @@
+#ifndef LIBZAZEN_KEYMAP_INFO_H
+#define LIBZAZEN_KEYMAP_INFO_H
+
+#include <xkbcommon/xkbcommon.h>
+#include <z11-server-protocol.h>
+
+struct zazen_keymap_info {
+  struct xkb_context *context;
+  struct xkb_rule_names *names;
+  struct xkb_keymap *keymap;
+
+  int fd;
+  size_t size;
+  enum z11_keyboard_keymap_format format;
+};
+
+struct zazen_keymap_info *zazen_keymap_info_create();
+
+void zazen_keymap_info_destroy(struct zazen_keymap_info *keymap_info);
+
+#endif  // LIBZAZEN_KEYMAP_INFO_H

--- a/libzazen/meson.build
+++ b/libzazen/meson.build
@@ -4,6 +4,7 @@ deps_libzazen = [
   dependency('glew'),
   dependency('libinput'),
   dependency('libudev'),
+  dependency('xkbcommon'),
 ]
 
 srcs_libzazen = files([
@@ -12,6 +13,7 @@ srcs_libzazen = files([
   'cuboid_window.c',
   'keyboard_client.c',
   'keyboard.c',
+  'keymap_info.c',
   'lib_input.c',
   'opengl_render_component_manager.c',
   'opengl_render_component.c',

--- a/libzazen/ray.c
+++ b/libzazen/ray.c
@@ -197,6 +197,8 @@ static void default_grab_ray_button(struct zazen_ray_grab* grab,
 
   ray_client = zazen_ray_find_ray_client(
       ray, wl_resource_get_client(focus_cuboid_window->resource));
+  if (ray_client == NULL) return;
+
   msecs = timespec_to_msec(time);
   wl_resource_for_each(resource, &ray_client->ray_resources)
   {

--- a/libzazen/seat.c
+++ b/libzazen/seat.c
@@ -8,7 +8,7 @@
 #include "compositor.h"
 #include "util.h"
 
-void zazen_seat_send_updated_capability(struct zazen_seat* seat)
+static void zazen_seat_send_updated_capability(struct zazen_seat* seat)
 {
   enum z11_seat_capability capability = 0;
   struct wl_resource* resource;
@@ -151,6 +151,8 @@ static void zazen_seat_protocol_get_keyboard(struct wl_client* client,
   }
 
   zazen_keyboard_client_add_resource(keyboard_client, keyboard_client_resource);
+
+  zazen_keyboard_notify_keymap(seat->keyboard, keyboard_client);
 }
 
 static const struct z11_seat_interface zazen_seat_interface = {

--- a/libzazen/util.c
+++ b/libzazen/util.c
@@ -31,6 +31,8 @@ int create_shared_file(off_t size, void* content)
 
   memcpy(data, content, size);
 
+  munmap(data, size);
+
   return fd;
 }
 

--- a/libzazen/util.c
+++ b/libzazen/util.c
@@ -1,7 +1,38 @@
+#define _GNU_SOURCE 1
+
 #include "util.h"
 
 #include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
 #include <wayland-server.h>
+
+int create_shared_file(off_t size, void* content)
+{
+  const char* name = "zazen-shared";
+  int fd;
+  void* data;
+
+  fd = memfd_create(name, MFD_CLOEXEC | MFD_ALLOW_SEALING);
+  if (fd < 0) return fd;
+  unlink(name);
+
+  if (ftruncate(fd, size) < 0) {
+    close(fd);
+    return -1;
+  }
+
+  data = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (data == MAP_FAILED) {
+    close(fd);
+    return -1;
+  }
+
+  memcpy(data, content, size);
+
+  return fd;
+}
 
 static void zazen_weak_pointer_handle_destroy_signal_handler(
     struct wl_listener* listener, void* data)

--- a/libzazen/util.h
+++ b/libzazen/util.h
@@ -2,12 +2,16 @@
 #define LIBZAZEN_UTIL_H
 
 #include <stdlib.h>
+#include <sys/mman.h>
 #include <wayland-server.h>
 
 #define UNUSED(x) ((void)x)
 
 #define _Nullable
 #define _NonNull
+
+/* fd */
+int create_shared_file(off_t size, void* content);
 
 /* helper function */
 inline void* zalloc(size_t size) { return calloc(1, size); }

--- a/protocol/z11.xml
+++ b/protocol/z11.xml
@@ -125,7 +125,7 @@
     <enum name="keymap_format">
       <description summary="keyboard mapping format">
 	      This specifies the format of the keymap provided to the
-	      client with the wl_keyboard.keymap event.
+	      client with the z11_keyboard.keymap event.
       </description>
       <entry name="no_keymap" value="0"
 	     summary="no keymap; client must understand how to interpret the raw keycode"/>

--- a/protocol/z11.xml
+++ b/protocol/z11.xml
@@ -122,6 +122,31 @@
   <interface name="z11_keyboard" version="1">
     <description summary="keyboard input device">TBD</description>
 
+    <enum name="keymap_format">
+      <description summary="keyboard mapping format">
+	      This specifies the format of the keymap provided to the
+	      client with the wl_keyboard.keymap event.
+      </description>
+      <entry name="no_keymap" value="0"
+	     summary="no keymap; client must understand how to interpret the raw keycode"/>
+      <entry name="xkb_v1" value="1"
+	     summary="libxkbcommon compatible; to determine the xkb keycode, clients must add 8 to the key event keycode"/>
+    </enum>
+
+    <event name="keymap">
+      <description summary="keyboard mapping">
+	      This event provides a file descriptor to the client which can be
+	      memory-mapped in read-only mode to provide a keyboard mapping
+	      description.
+
+	      From version 7 onwards, the fd must be mapped with MAP_PRIVATE by
+	      the recipient, as MAP_SHARED may fail.
+      </description>
+      <arg name="format" type="uint" enum="keymap_format" summary="keymap format"/>
+      <arg name="fd" type="fd" summary="keymap file descriptor"/>
+      <arg name="size" type="uint" summary="keymap size, in bytes"/>
+    </event>
+
     <event name="enter">
       <description summary="enter event">TBD</description>
       <arg name="serial" type="uint" summary="serial number of the enter event"/>

--- a/zazen/render_system.cc
+++ b/zazen/render_system.cc
@@ -5,6 +5,7 @@
 void RenderSystem::Render(Eye *eye,
                           ZServer::RenderStateIterator *render_state_iterator)
 {
+  glLineWidth(2);
   glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
 
   glEnable(GL_MULTISAMPLE);


### PR DESCRIPTION
keymapイベントを追加してweston-terminalなどにkey入力できるようにした。
デモを試すには、
https://github.com/gray-armor/zsurface/pull/6
https://github.com/gray-armor/zwayland/pull/12
を取り込む必要があります。

ついでにCIのカスタムしたwaylandを使用する設定を、libwayland-devを使う設定に変更しておきました。

以下の挙動は把握済みで、今後直しておきます。
- Chromeにキー入力できない

[![alt設定](http://img.youtube.com/vi/bzPGlK5rYC8/0.jpg)](https://www.youtube.com/watch?v=bzPGlK5rYC8)