### PR TITLE
Remove dependency on xkbcommon

### DIFF
--- a/libzazen/keymap_info.h
+++ b/libzazen/keymap_info.h
@@ -1,14 +1,9 @@
 #ifndef LIBZAZEN_KEYMAP_INFO_H
 #define LIBZAZEN_KEYMAP_INFO_H
 
-#include <xkbcommon/xkbcommon.h>
 #include <z11-server-protocol.h>
 
 struct zazen_keymap_info {
-  struct xkb_context *context;
-  struct xkb_rule_names *names;
-  struct xkb_keymap *keymap;
-
   int fd;
   size_t size;
   enum z11_keyboard_keymap_format format;


### PR DESCRIPTION
やっぱりkeyboardやkeymap_infoがxkbcommonに依存してるのが気持ち悪かったので依存性を取り除きました。